### PR TITLE
fix: Safari apostrophe JS syntax error causing blank screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -5270,7 +5270,7 @@ function _updateInstallCard() {
     if (installBtn) installBtn.style.display = 'flex';
     if (iosBtn) iosBtn.style.display = 'none';
   } else if (isIOS) {
-    status.innerHTML = '<div class="hint"><i class="fas fa-info-circle"></i><span>Safari'de "Paylaş → Ana Ekrana Ekle" adımlarını izleyin.</span></div>';
+    status.innerHTML = '<div class="hint"><i class="fas fa-info-circle"></i><span>Safari\'de "Paylaş → Ana Ekrana Ekle" adımlarını izleyin.</span></div>';
     if (installBtn) installBtn.style.display = 'none';
     if (iosBtn) iosBtn.style.display = 'flex';
   } else {


### PR DESCRIPTION
https://claude.ai/code/session_018t5FPKK4Wzx553rFerAVQc