### PR TITLE
fix: gece vardiyası yanlış tespiti ve FM etiket belirsizliği düzeltildi

### DIFF
--- a/index.html
+++ b/index.html
@@ -1689,7 +1689,8 @@ function grossHr(s, e) {
 function isNightShift(start, end) {
   const st = parseTime(start), en = parseTime(end);
   if (st === null || en === null) return false;
-  return en < st; // çıkış < giriş → gece geçişi
+  if (en === 0) return false; // 00:00 bitiş = gece yarısında sona eriyor, ertesi güne taşmıyor
+  return en < st; // çıkış < giriş → gece geçişi (örn. 22:00–06:00)
 }
 
 function getISOWeek(d) {
@@ -2302,7 +2303,7 @@ function renderDash() {
     <div class="info-row"><span class="k"><i class="fas fa-umbrella-beach"></i>Kalan Y.İzin</span><span class="v ${ar <= 3 ? 'neg' : ''}">${ar}g</span></div>
     <div class="info-row"><span class="k"><i class="fas fa-notes-medical"></i>Rapor (yıl)</span><span class="v">${d.ysd}g</span></div>
     <div class="info-row"><span class="k"><i class="fas fa-couch"></i>H.Tatil (ay)</span><span class="v">${d.wr}g</span></div>
-    <div class="info-row"><span class="k"><i class="fas fa-coins"></i>Saatlik</span><span class="v">${u.netSalary ? fm(d.hr) : '—'}</span></div>
+    <div class="info-row"><span class="k"><i class="fas fa-coins"></i>Saatlik (baz)</span><span class="v">${u.netSalary ? fm(d.hr) : '—'}</span></div>
     <div class="info-row"><span class="k"><i class="fas fa-chart-line"></i>İş Günü Dol.</span><span class="v">${d.dim > 0 ? workdays + '/' + d.dim : '—'}</span></div>
   `;
   // Year comparison
@@ -2390,7 +2391,7 @@ function renderDashReports(u, d, e) {
       <div class="dr-row"><span class="drk"><i class="fas fa-fire" style="color:var(--acc)"></i>FM Eki</span><span class="drv accent">${fm(e.overtimePay)} <small style="color:var(--t3)">(${otPct}%)</small></span></div>
       <div class="dr-row"><span class="drk"><i class="fas fa-flag" style="color:var(--r)"></i>Tatil Eki</span><span class="drv accent">${fm(e.holidayPay)} <small style="color:var(--t3)">(${holPct}%)</small></span></div>
       <div class="dr-row"><span class="drk"><i class="fas fa-coins" style="color:var(--p)"></i>Günlük</span><span class="drv">${fm(e.dailyRate)}</span></div>
-      <div class="dr-row"><span class="drk"><i class="fas fa-clock" style="color:var(--p)"></i>Saatlik</span><span class="drv">${fm(e.hourlyRate)}</span></div>`;
+      <div class="dr-row"><span class="drk"><i class="fas fa-clock" style="color:var(--p)"></i>Saatlik (baz)</span><span class="drv">${fm(e.hourlyRate)}</span></div>`;
   } else {
     earnMini = '<div style="font-size:11px;color:var(--t3);text-align:center;padding:8px">Maaş bilgisi girilmemiş</div>';
   }
@@ -3555,7 +3556,7 @@ function renderEarn() {
       <div class="esd"><span class="ek"><i class="fas fa-money-bill"></i>Net Maaş</span><span class="ev">${fm(u.netSalary)}</span></div>
       ${e.absentDays > 0 ? `<div class="esd"><span class="ek"><i class="fas fa-minus-circle"></i>Kesinti (${e.absentDays}g)</span><span class="ev neg">−${fm(e.absentDays*e.dailyRate)}</span></div>` : ''}
       <div class="esd"><span class="ek"><i class="fas fa-equals"></i>Maaş (baz)</span><span class="ev">${fm(e.basePay)}</span></div>
-      <div class="esd"><span class="ek"><i class="fas fa-fire"></i>FM ek (${e.overtimeHours.toFixed(1)}s × ½)</span><span class="ev pos">+${fm(e.overtimePay)}</span></div>
+      <div class="esd"><span class="ek"><i class="fas fa-fire"></i>FM ek (${e.overtimeHours.toFixed(1)}s × ${fm(e.hourlyRate)} × ½)</span><span class="ev pos">+${fm(e.overtimePay)}</span></div>
       <div class="esd"><span class="ek"><i class="fas fa-flag"></i>Tatil ek (${e.holidayHours.toFixed(1)}s × 1)</span><span class="ev pos">+${fm(e.holidayPay)}</span></div>
       ${(e.hhOT||0) > 0 ? `<div class="esd" style="opacity:.6;font-size:11px"><span class="ek"><i class="fas fa-info-circle"></i>Tatil+FM çakışan saat</span><span class="ev">${e.hhOT.toFixed(1)}s (tatil+FM eki uygulandı)</span></div>` : ''}
       <div class="esd total"><span class="ek"><i class="fas fa-wallet"></i><b>TOPLAM</b></span><span class="ev">${fm(e.totalEarning)}</span></div>
@@ -6546,7 +6547,7 @@ function runCalc() {
         <div class="cd-item"><div class="cd-val" style="color:var(--g)">${fm(basePay)}</div><div class="cd-lbl">Baz Maaş</div></div>
         <div class="cd-item"><div class="cd-val" style="color:var(--acc)">${fm(otPay)}</div><div class="cd-lbl">FM Eki</div></div>
         <div class="cd-item"><div class="cd-val">${fm(dr)}</div><div class="cd-lbl">Günlük Ücret</div></div>
-        <div class="cd-item"><div class="cd-val">${fm(hr)}</div><div class="cd-lbl">Saatlik Ücret</div></div>
+        <div class="cd-item"><div class="cd-val">${fm(hr)}</div><div class="cd-lbl">Saatlik (baz)</div></div>
       ` : `<div class="cd-item" style="grid-column:span 2"><div class="cd-val" style="color:var(--t3);font-size:11px">Kazanç için Ayarlar'dan maaş girin</div><div class="cd-lbl">&nbsp;</div></div>`}
     </div>
   </div>`;


### PR DESCRIPTION
- isNightShift: 00:00 bitişli vardiyalar (13/24, 16/24 gibi) artık yanlışlıkla "Gece" sınıflandırılmıyor. parseTime("00:00") = 0 olduğundan en < st koşulu her zaman true dönüyordu; en === 0 kontrolü eklenerek gece yarısında biten ama ertesi güne taşmayan vardiyalar doğru tespit ediliyor.

- FM ek etiketi: "Xs × ½" yerine "Xs × 276₺ × ½" formatında saatlik baz ücret gösterilerek hesaplama şeffaflaştırıldı.

- "Saatlik" etiketleri "Saatlik (baz)" olarak güncellendi; kullanıcı bunu fazla mesai saatlik ücreti ile karıştırmasın.

https://claude.ai/code/session_01GLHeGZ3vRiGHBaW2SoUSzT