### PR TITLE
feat: Detaylı Kazanç Analizi & Canlı Takip (3 yeni özellik)

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,6 +484,7 @@ tr:hover td{background:var(--bg3)}
 .esb .esd .ev.pos{color:var(--g)}.esb .esd .ev.neg{color:var(--r)}
 .esb .esd.total{border-top:1.5px solid var(--b2);padding-top:10px;margin-top:4px;font-size:14px}
 .esb .esd.total .ev{color:var(--p);font-size:16px}
+.esb .esd-head{font-size:10px;font-weight:800;letter-spacing:.6px;color:var(--p);padding:8px 0 2px;border-top:1px solid var(--b1);margin-top:4px;text-transform:uppercase}
 .cal-earn-bar{background:var(--p4);border:1px solid var(--b1);border-radius:10px;padding:10px 14px;margin-top:12px;display:flex;align-items:center;justify-content:space-between;font-size:12px;font-weight:600;gap:12px;flex-wrap:wrap}
 .cal-earn-bar .ceb{display:flex;align-items:center;gap:5px;color:var(--t2)}
 .cal-earn-bar .ceb b{font-weight:800;color:var(--t1)}.cal-earn-bar .ceb b.accent{color:var(--p)}
@@ -1145,6 +1146,8 @@ tr:hover td{background:var(--bg3)}
       <div id="dashOTComp"></div>
       <!-- [FIX] AI Rapor Özeti kartı -->
       <div id="dashAISummary"></div>
+      <!-- Yıllık Kümülatif Kazanç widget -->
+      <div id="dashYearlyCumul"></div>
       <div id="dashGoal" class="goal-wrap"></div>
       <div class="year-overview-wrap" id="yearOverviewWrap"></div>
       <div id="dashLast7Days"></div>
@@ -2386,6 +2389,7 @@ function renderDash() {
   /* [FIX] FM İzin Bakiyesi + AI Rapor Özeti kartları */
   renderDashOTComp();
   renderDashAISummary();
+  renderDashYearlyCumul();
   renderDashLast7Days();
   renderDashWeekSummary();
   renderDashHeatmap();
@@ -3146,12 +3150,22 @@ function saveEntry() {
       pushUndo('Vardiya');
       const snEl = $('iShiftNote');
       const note = (snEl ? snEl.value : '').trim().substring(0, 100);
+      /* Canlı Kazanç Bildirimi — kayıt öncesi kazanç */
+      const _p = parseDS(S.sd);
+      const _eBefore = (_p && u.netSalary) ? calcEarningForMonth(_p.y, _p.m, u.netSalary) : null;
       u.shifts[S.sd] = { start:st, end:en, break:br, note, updatedAt:Date.now() };
       if (u.deletedShifts) delete u.deletedShifts[S.sd];
       if (u.leaves[S.sd]) { if (!u.deletedLeaves) u.deletedLeaves = {}; u.deletedLeaves[S.sd] = Date.now(); }
       delete u.leaves[S.sd];
-      toast(`${hrs.toFixed(1)}s kaydedildi`, 'success');
-      invalidateMDCache(); saveLS(); closeM(); renderActivePage();
+      invalidateMDCache();
+      /* Canlı Kazanç Bildirimi — kayıt sonrası kazanç farkı */
+      const _eAfter = (_p && u.netSalary) ? calcEarningForMonth(_p.y, _p.m, u.netSalary) : null;
+      if (_eBefore && _eAfter && (_eAfter.totalEarning - _eBefore.totalEarning) > 0.5) {
+        toast(`✅ ${hrs.toFixed(1)}s eklendi — Kazancına ~${fm(_eAfter.totalEarning - _eBefore.totalEarning)} eklendi`, 'success');
+      } else {
+        toast(`${hrs.toFixed(1)}s kaydedildi`, 'success');
+      }
+      saveLS(); closeM(); renderActivePage();
     };
 
     // Rest time check
@@ -3634,12 +3648,24 @@ function renderEarn() {
       <div class="esb-item"><div class="esb-val">${fm(e.dailyRate)}</div><div class="esb-lbl">Günlük</div></div>
     </div>
     <div class="esb-detail">
-      <div class="esd"><span class="ek"><i class="fas fa-money-bill"></i>Net Maaş</span><span class="ev">${fm(u.netSalary)}</span></div>
-      ${e.absentDays > 0 ? `<div class="esd"><span class="ek"><i class="fas fa-minus-circle"></i>Kesinti (${e.absentDays}g)</span><span class="ev neg">−${fm(e.absentDays*e.dailyRate)}</span></div>` : ''}
-      <div class="esd"><span class="ek"><i class="fas fa-equals"></i>Maaş (baz)</span><span class="ev">${fm(e.basePay)}</span></div>
-      <div class="esd"><span class="ek"><i class="fas fa-fire"></i>FM ek (${e.overtimeHours.toFixed(1)}s × ${fm(e.hourlyRate)} × 1½)</span><span class="ev pos">+${fm(e.overtimePay)}</span></div>
-      <div class="esd"><span class="ek"><i class="fas fa-flag"></i>Tatil ek (${e.holidayHours.toFixed(1)}s × 1)</span><span class="ev pos">+${fm(e.holidayPay)}</span></div>
-      ${(e.hhOT||0) > 0 ? `<div class="esd" style="opacity:.6;font-size:11px"><span class="ek"><i class="fas fa-info-circle"></i>Tatil+FM çakışan saat</span><span class="ev">${e.hhOT.toFixed(1)}s (tatil+FM eki uygulandı)</span></div>` : ''}
+      <div class="esd-head">💰 MAAŞ (BAZ)</div>
+      <div class="esd"><span class="ek">Net Maaş</span><span class="ev">${fm(u.netSalary)}</span></div>
+      <div class="esd"><span class="ek">Saatlik Ücret</span><span class="ev">${fm(e.hourlyRate)}/s</span></div>
+      <div class="esd" style="font-weight:600"><span class="ek">Baz Kazanç (${e.paidDays}g ücretli)</span><span class="ev">${fm(e.basePay)}</span></div>
+      ${e.absentDays > 0 ? `
+      <div class="esd-head" style="color:var(--r)">⛔ KESİNTİLER</div>
+      ${e.unpaidDays > 0 ? `<div class="esd"><span class="ek">Ücretsiz İzin (${e.unpaidDays}g × ${fm(e.dailyRate)})</span><span class="ev neg">−${fm(e.unpaidDays*e.dailyRate)}</span></div>` : ''}
+      ${e.missingDays > 0 ? `<div class="esd"><span class="ek">Eksik Gün (${e.missingDays}g × ${fm(e.dailyRate)})</span><span class="ev neg">−${fm(e.missingDays*e.dailyRate)}</span></div>` : ''}
+      ` : ''}
+      ${e.overtimePay > 0 ? `
+      <div class="esd-head" style="color:#f97316">🔥 FAZLA MESAİ (1.5×)</div>
+      <div class="esd"><span class="ek">${e.overtimeHours.toFixed(1)}s × ${fm(e.hourlyRate)} × 1.5</span><span class="ev pos">+${fm(e.overtimePay)}</span></div>
+      ` : ''}
+      ${e.holidayPay > 0 ? `
+      <div class="esd-head" style="color:var(--g)">🏛️ TATİL PRİMLERİ</div>
+      <div class="esd"><span class="ek">${e.holidayHours.toFixed(1)}s tatil çalışması × ${fm(e.hourlyRate)}</span><span class="ev pos">+${fm(e.holidayPay)}</span></div>
+      ${(e.hhOT||0) > 0 ? `<div class="esd" style="opacity:.65;font-size:11px"><span class="ek" style="padding-left:8px">↳ ${e.hhOT.toFixed(1)}s tatil+FM çakışan saat dahil</span><span class="ev"></span></div>` : ''}
+      ` : ''}
       <div class="esd total"><span class="ek"><i class="fas fa-wallet"></i><b>TOPLAM</b></span><span class="ev">${fm(e.totalEarning)}</span></div>
     </div>
   </div>
@@ -5055,6 +5081,63 @@ function renderDashAISummary() {
   el.innerHTML = `<div class="ai-sum-card">
     <div class="ais-head"><i class="fas fa-robot" style="color:var(--acc)"></i>AI Rapor Özeti</div>
     ${items}
+  </div>`;
+}
+
+/** Dashboard — Yıllık Kümülatif Kazanç widget'ı */
+function renderDashYearlyCumul() {
+  const el = $('dashYearlyCumul'); if (!el) return;
+  const u = cu(); if (!u || !u.netSalary) { el.innerHTML = ''; return; }
+  const today = new Date();
+  const curY = today.getFullYear(), curM = today.getMonth();
+  /* Sadece görüntülenen yıl mevcut yıl ise göster */
+  if (S.cy !== curY) { el.innerHTML = ''; return; }
+
+  let cumul = 0, maxVal = 0;
+  const months = [];
+  for (let mi = 0; mi <= curM; mi++) {
+    const me = calcEarningForMonth(curY, mi, u.netSalary);
+    const mEarn = (me && !me.isFutureMonth) ? me.totalEarning : 0;
+    cumul += mEarn;
+    months.push({ label: MTR[mi].substring(0, 3), earn: mEarn, cumul, isCur: mi === curM });
+    if (mEarn > maxVal) maxVal = mEarn;
+  }
+  if (cumul === 0) { el.innerHTML = ''; return; }
+
+  const avg = months.filter(m => m.earn > 0).length > 0
+    ? cumul / months.filter(m => m.earn > 0).length : 0;
+  const remaining = 12 - (curM + 1);
+  const projected = cumul + avg * remaining;
+  const progPct = Math.round(((curM + 1) / 12) * 100);
+
+  let bars = '';
+  months.forEach(mo => {
+    const h = maxVal > 0 ? Math.max(4, (mo.earn / maxVal * 100)) : 4;
+    const bg = mo.isCur ? 'var(--pg)' : mo.earn > 0 ? 'var(--p4)' : 'var(--bg3)';
+    bars += `<div style="display:flex;flex-direction:column;align-items:center;gap:2px;flex:1;min-width:0" title="${mo.label}: ${fm(mo.earn)}">
+      <div style="width:100%;height:${h}px;background:${bg};border-radius:3px 3px 0 0;border:1px solid var(--b1)"></div>
+      <span style="font-size:8px;color:var(--t3);font-weight:600">${mo.label}</span>
+    </div>`;
+  });
+
+  el.innerHTML = `<div class="card" style="margin-bottom:12px">
+    <div class="card-head">
+      <h3><i class="fas fa-chart-line" style="color:var(--g)"></i>Yıllık Kazanç (${curY})</h3>
+      <span style="font-size:10px;color:var(--t3)">${MTR[0].substring(0,3)}–${MTR[curM].substring(0,3)}</span>
+    </div>
+    <div style="display:flex;gap:12px;margin-bottom:10px;flex-wrap:wrap">
+      <div><div style="font-size:18px;font-weight:900;color:var(--g)">${fm(cumul)}</div><div style="font-size:10px;color:var(--t3)">${curM+1} ay toplam</div></div>
+      <div><div style="font-size:14px;font-weight:800;color:var(--p3)">${fm(avg)}</div><div style="font-size:10px;color:var(--t3)">aylık ortalama</div></div>
+      ${remaining > 0 ? `<div><div style="font-size:12px;font-weight:700;color:var(--t2)">~${fm(projected)}</div><div style="font-size:10px;color:var(--t3)">yıl sonu tahmini</div></div>` : ''}
+    </div>
+    <div style="display:flex;align-items:flex-end;gap:2px;height:48px;margin-bottom:6px">${bars}</div>
+    <div style="background:var(--bg2);border-radius:4px;height:6px;overflow:hidden">
+      <div style="height:100%;width:${progPct}%;background:var(--pg);border-radius:4px;transition:width .4s"></div>
+    </div>
+    <div style="display:flex;justify-content:space-between;margin-top:4px;font-size:10px;color:var(--t3)">
+      <span>Yılın %${progPct}'i geçti</span>
+      <span>${remaining > 0 ? remaining + ' ay kaldı' : 'Yıl tamamlandı'}</span>
+    </div>
   </div>`;
 }
 


### PR DESCRIPTION
A) Canlı Kazanç Bildirimi: saveEntry() içinde vardiya kaydedilince
   calcEarningForMonth farkı hesaplanır; maaş girilmişse toast olarak
   '✅ Xs eklendi — Kazancına ~Y₺ eklendi' gösterilir.

B) Gelişmiş Kazanç Breakdown: renderEarn() esb-detail bölümü yeniden
   tasarlandı — 💰 Maaş (Baz), ⛔ Kesintiler (ayrı satırda ücretsiz izin
   / eksik gün), 🔥 Fazla Mesai (Xs × ücret × 1.5 formülüyle), 🏛️ Tatil
   Primleri; her kategori kendi başlığıyla ayrıldı. .esd-head CSS eklendi.

C) Yıllık Kümülatif Kazanç Widget: Dashboard'a renderDashYearlyCumul()
   eklendi — Ocak–bugün toplam, aylık ortalama, yıl sonu tahmini ve
   ay bazlı çubuk grafik + ilerleme çubuğu gösterilir.

https://claude.ai/code/session_01GLHeGZ3vRiGHBaW2SoUSzT