### PR TITLE
fix: 6 İş Kanunu hesaplama hatası düzeltildi (kod denetimi)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1343,8 +1343,8 @@ tr:hover td{background:var(--bg3)}
 
       <div class="card s-card">
         <h3><i class="fas fa-bullseye"></i>Aylık Saat Hedefi</h3>
-        <div class="hint"><i class="fas fa-lightbulb"></i><span>Saatlik ücret hesaplaması için aylık toplam çalışma saati. Varsayılan: 225 saat.</span></div>
-        <div class="fg"><label>Aylık Saat</label><input type="number" id="sMH" placeholder="225" min="100" max="400" step="5" onchange="sSet('monthlyHours',this.value)"></div>
+        <div class="hint"><i class="fas fa-lightbulb"></i><span>Saatlik ücret hesaplaması için aylık toplam çalışma saati. Varsayılan: 195 (45s×52.18hf÷12ay — matematiksel doğru). Yargıtay içtihadına göre 225 de kullanılabilir.</span></div>
+        <div class="fg"><label>Aylık Saat</label><input type="number" id="sMH" placeholder="195" min="100" max="400" step="5" onchange="sSet('monthlyHours',this.value)"></div>
       </div>
 
       <!-- [FIX] Fazla Mesai → İzin Karşılığı (Comp Time) -->
@@ -1487,6 +1487,7 @@ tr:hover td{background:var(--bg3)}
       <div id="mAlert" class="h-alert" style="display:none"><i class="fas fa-flag"></i><span id="mAlertTx"></span></div>
       <div id="mConflictWarn" class="h-warn" style="display:none"><i class="fas fa-exclamation-triangle"></i><span id="mConflictTx"></span></div>
       <div id="mNightInfo" class="h-info" style="display:none"><i class="fas fa-moon"></i><span id="mNightTx"></span></div>
+      <div id="mBreakInfo" class="h-info" style="display:none;color:var(--r)"><i class="fas fa-coffee"></i><span id="mBreakTx"></span></div>
       <div class="mode-tabs">
         <button class="mode-tab active" onclick="mMode('shift',this)"><i class="fas fa-clock"></i>Vardiya</button>
         <button class="mode-tab" onclick="mMode('leave',this)"><i class="fas fa-umbrella-beach"></i>İzin</button>
@@ -1547,7 +1548,7 @@ const MTR = ['Ocak','Şubat','Mart','Nisan','Mayıs','Haziran','Temmuz','Ağusto
 const DTR = ['Pzt','Sal','Çar','Per','Cum','Cmt','Paz'];
 /* [FIX L-01] DFS, DTR ile aynıydı — kaldırıldı, kullanımlar DTR'ye yönlendirildi */
 const DFL = ['Pazartesi','Salı','Çarşamba','Perşembe','Cuma','Cumartesi','Pazar'];
-let MH = 225;
+let MH = 195;  // 45s × 52.18hf ÷ 12ay = 195.7 (matematiksel doğru); Yargıtay içtihadı için kullanıcı 225 seçebilir
 const MAX_GROSS_HOURS = 16;
 const PRESETS_BASE = Object.freeze({
   morning:   { start:'08:00', end:'16:00', break:30 },
@@ -1617,7 +1618,7 @@ function mkUser(i) {
     notes: '',
     lastLogin: null,
     theme: 'default',
-    monthlyHours: 225,
+    monthlyHours: 195,
     goalHours: 0,
     goalEarning: 0,
     pin: null,
@@ -1988,7 +1989,7 @@ function getMD(y, m) {
     if (p.y === y && p.m === m) {
       if (v.type === 'annual') mau++;
       if (v.type === 'sick') msd++;
-      if (v.type === 'weekly') wr++;
+      if (v.type === 'weekly' || v.type === 'public_holiday') wr++;
       if (v.type === 'unpaid') ud++;
       /* [FIX] FM İzni — ücretli, yıllık izinden bağımsız, otBalance'tan düşülür */
       if (v.type === 'ot_comp') otcm++;
@@ -2047,7 +2048,9 @@ function calcEarningForMonth(y, m, ns) {
   const ab = d.ud + mis;
   const bp = Math.max(0, ns - (ab * dr));
 
-  const hp = d.hh * hr;
+  /* [FIX Md.47] Tatil çalışması ilave ücreti: basePay içinde normal tatil ücreti zaten var;
+     Madde 47 gereği ilave 1 günlük ücret daha ödenir → hdw × dr (saat değil gün bazlı) */
+  const hp = d.hdw * dr;
   /* [FIX] otCompMode: 'leave' modunda FM eki ödenmez, saatler bakiyeye eklenir */
   const compMode = u.otCompMode || 'pay';
   const compRate = parseFloat(u.otCompRate) || 1.5;
@@ -2060,7 +2063,7 @@ function calcEarningForMonth(y, m, ns) {
     paidDays: pd, workedDays: d.wd, weeklyDays: d.wr,
     annualDays: d.mau, sickDays: d.msd, unpaidDays: d.ud, otCompDays: d.otcm || 0,
     missingDays: mis, absentDays: ab, freePassDays: fp,
-    dim, totalHours: d.th, overtimeHours: d.oh, holidayHours: d.hh,
+    dim, totalHours: d.th, overtimeHours: d.oh, holidayHours: d.hh, holidayDays: d.hdw,
     hhOT: d.hhOT || 0, otCompMode: compMode,
     isFullMonth: ab === 0 && !isCur && !isFut,
     isCurrentMonth: isCur, isFutureMonth: isFut, evaluableDays: ev
@@ -2701,8 +2704,8 @@ function renderCal() {
       if (hol) inner += `<span class="hol-tag">🏛️ ${escHtml(hol)}</span>`;
     } else if (lv && lv.type) {
       /* [FIX] FM İzni dahil tüm izin türleri */
-      const ic = { annual:'fa-umbrella-beach', weekly:'fa-couch', sick:'fa-notes-medical', unpaid:'fa-ban', ot_comp:'fa-exchange-alt' };
-      const lb = { annual:'Y.İzin', weekly:'H.Tatil', sick:'Rapor', unpaid:'Ücretsiz', ot_comp:'FM İzni' };
+      const ic = { annual:'fa-umbrella-beach', weekly:'fa-couch', public_holiday:'fa-flag', sick:'fa-notes-medical', unpaid:'fa-ban', ot_comp:'fa-exchange-alt' };
+      const lb = { annual:'Y.İzin', weekly:'H.Tatil', public_holiday:'R.Tatil', sick:'Rapor', unpaid:'Ücretsiz', ot_comp:'FM İzni' };
       inner += `<div class="leave-display ld-${lv.type}"><i class="fas ${ic[lv.type]||'fa-circle'}"></i>${lb[lv.type]||''}</div>`;
       inner += `<span class="leave-label ll-${lv.type}">${lb[lv.type]||''}</span>`;
       if (hol) inner += `<span class="hol-tag">${escHtml(hol)}</span>`;
@@ -2715,7 +2718,7 @@ function renderCal() {
     e.setAttribute('tabindex', '0');
     e.setAttribute('role', 'button');
     /* [FIX ERİŞİLEBİLİRLİK-01] Ekran okuyucuya vardiya saatleri ve izin türü iletiliyor */
-    const _lvA11y = {annual:'Yıllık İzin',weekly:'Haftalık Tatil',sick:'Rapor',unpaid:'Ücretsiz İzin',ot_comp:'FM İzni'};
+    const _lvA11y = {annual:'Yıllık İzin',weekly:'Haftalık Tatil',public_holiday:'Resmi Tatil',sick:'Rapor',unpaid:'Ücretsiz İzin',ot_comp:'FM İzni'};
     const _a11yDesc = sh ? `${sh.start}–${sh.end} (${calcHr(sh.start,sh.end,sh.break||0).toFixed(1)}s)${hol?' — '+hol:''}` : lv ? (_lvA11y[lv.type]||'İzin') : hol || 'Boş';
     e.setAttribute('aria-label', `${d} ${MTR[m]} ${y}: ${_a11yDesc}`);
     if (sh && sh.start) e.draggable = true;
@@ -3000,7 +3003,7 @@ function openM(ds) {
       setTxt('mConflictTx', 'Bu günde zaten vardiya var. Değiştirebilir veya silebilirsiniz.');
     } else if (lv && lv.type) {
       cw.style.display = 'flex';
-      setTxt('mConflictTx', 'Bu günde ' + {annual:'yıllık izin',weekly:'hafta tatili',sick:'rapor',unpaid:'ücretsiz izin'}[lv.type] + ' var. Üzerine yazabilirsiniz.');
+      setTxt('mConflictTx', 'Bu günde ' + {annual:'yıllık izin',weekly:'hafta tatili',public_holiday:'resmi tatil',sick:'rapor',unpaid:'ücretsiz izin'}[lv.type] + ' var. Üzerine yazabilirsiniz.');
     } else { cw.style.display = 'none'; }
   }
 
@@ -3094,7 +3097,7 @@ function mMode(t, btn) {
       const sh = u.shifts[S.sd], lv = u.leaves[S.sd];
       if (t === 'shift' && lv && lv.type) {
         cw.style.display = 'flex';
-        setTxt('mConflictTx', 'Bu günde ' + {annual:'yıllık izin',weekly:'hafta tatili',sick:'rapor',unpaid:'ücretsiz izin'}[lv.type] + ' var. Kaydetmek üzerine yazacak.');
+        setTxt('mConflictTx', 'Bu günde ' + {annual:'yıllık izin',weekly:'hafta tatili',public_holiday:'resmi tatil',sick:'rapor',unpaid:'ücretsiz izin'}[lv.type] + ' var. Kaydetmek üzerine yazacak.');
       } else if (t === 'leave' && sh && sh.start) {
         cw.style.display = 'flex';
         setTxt('mConflictTx', 'Bu günde ' + sh.start + '–' + sh.end + ' vardiyası var. Kaydetmek üzerine yazacak.');
@@ -3169,6 +3172,18 @@ function updResult() {
     }
   }
 
+  /* [FIX Md.68] Zorunlu ara dinlenme kontrolü */
+  const bi = $('mBreakInfo');
+  if (bi) {
+    const minBreak = net > 7.5 ? 60 : net > 4 ? 30 : net > 0 ? 15 : 0;
+    if (minBreak > 0 && b < minBreak) {
+      bi.style.display = 'flex';
+      setTxt('mBreakTx', `Md.68: ${net.toFixed(1)}s çalışma için en az ${minBreak} dk mola zorunlu (girilen: ${b} dk).`);
+    } else {
+      bi.style.display = 'none';
+    }
+  }
+
   const u = cu(); const ep = $('mEarningPreview'); if (!ep) return;
   if (u && u.netSalary > 0 && net > 0) {
     const _mh2 = (u.monthlyHours && u.monthlyHours > 0) ? u.monthlyHours : (MH || 225);
@@ -3181,7 +3196,7 @@ function updResult() {
     const weekWithShift = getWeekOTForDay(S.sd, net);
     const shiftOT = Math.max(0, weekWithShift.ot - prevWeek.ot);
     let earn = 0;
-    if (isHol2) earn += net * hr;
+    if (isHol2) earn += u.netSalary / 30;  // Md.47: ilave 1 günlük ücret
     if (shiftOT > 0) earn += shiftOT * hr * 1.5;
     ep.textContent = earn > 0 ? `💰 Tahmini ek: ~${fm(earn)}` : '';
   } else { ep.textContent = ''; }
@@ -3201,6 +3216,12 @@ function saveEntry() {
     if (gross > MAX_GROSS_HOURS) { toast(`Vardiya ${MAX_GROSS_HOURS}s brüt aşamaz`, 'error'); return; }
     const hrs = calcHr(st, en, br);
     if (hrs <= 0) { toast('Mola vardiya süresinden uzun olamaz', 'error'); return; }
+
+    /* [FIX Md.68] Zorunlu mola uyarısı — engellemez, bildirir */
+    const _minBrk = hrs > 7.5 ? 60 : hrs > 4 ? 30 : hrs > 0 ? 15 : 0;
+    if (_minBrk > 0 && br < _minBrk) {
+      toast(`Uyarı (Md.68): ${hrs.toFixed(1)}s çalışma için en az ${_minBrk} dk mola girilmeli.`, 'warning');
+    }
 
     const doSave = () => {
       pushUndo('Vardiya');
@@ -3537,7 +3558,7 @@ function renderLeaves() {
     const p = parseDS(k); if (!p || p.y !== y || !v || !v.type) return;
     if (v.type === 'annual') yau++;
     if (v.type === 'sick') ysd++;
-    if (v.type === 'weekly') wr_year++;
+    if (v.type === 'weekly' || v.type === 'public_holiday') wr_year++;
     if (v.type === 'unpaid') ud_year++;
   });
 
@@ -3595,7 +3616,7 @@ function renderLeaveTable() {
   const lt = $('leaveTable'); if (!lt) return;
   if (!all.length) { lt.innerHTML = '<div class="empty"><i class="fas fa-check-circle"></i><p>Kayıt yok</p></div>'; return; }
 
-  const tl = { annual:'Yıllık', weekly:'H.Tatil', sick:'Rapor', unpaid:'Ücretsiz' };
+  const tl = { annual:'Yıllık', weekly:'H.Tatil', public_holiday:'R.Tatil', sick:'Rapor', unpaid:'Ücretsiz' };
   const tc = { annual:'a', weekly:'w', sick:'s', unpaid:'u' };
   let t = '<table><thead><tr><th>Tarih</th><th>Gün</th><th>Tür</th><th>Not</th><th></th></tr></thead><tbody>';
   all.forEach(([k, v]) => {
@@ -3724,7 +3745,7 @@ function renderEarn() {
       ` : ''}
       ${e.holidayPay > 0 ? `
       <div class="esd-head" style="color:var(--g)">🏛️ TATİL PRİMLERİ</div>
-      <div class="esd"><span class="ek">${e.holidayHours.toFixed(1)}s tatil çalışması × ${fm(e.hourlyRate)}</span><span class="ev pos">+${fm(e.holidayPay)}</span></div>
+      <div class="esd"><span class="ek">${e.holidayDays}g tatil × ${fm(e.dailyRate)} ilave (Md.47)</span><span class="ev pos">+${fm(e.holidayPay)}</span></div>
       ${(e.hhOT||0) > 0 ? `<div class="esd" style="opacity:.65;font-size:11px"><span class="ek" style="padding-left:8px">↳ ${e.hhOT.toFixed(1)}s tatil+FM çakışan saat dahil</span><span class="ev"></span></div>` : ''}
       ` : ''}
       <div class="esd total"><span class="ek"><i class="fas fa-wallet"></i><b>TOPLAM</b></span><span class="ev">${fm(e.totalEarning)}</span></div>
@@ -4416,7 +4437,7 @@ function exportCSV() {
         const note = (sh.note || '').replace(/"/g, '""');
         csv += `${ds},${dayName},Vardiya,${sh.start},${sh.end},${sh.break||0},${net.toFixed(1)},${gross.toFixed(1)},"${note}"\n`;
       } else if (lv && lv.type) {
-        const tl = {annual:'Yıllık İzin',weekly:'Hafta Tatili',sick:'Rapor',unpaid:'Ücretsiz'};
+        const tl = {annual:'Yıllık İzin',weekly:'Hafta Tatili',public_holiday:'Resmi Tatil',sick:'Rapor',unpaid:'Ücretsiz'};
         const note = (lv.note || '').replace(/"/g, '""');
         csv += `${ds},${dayName},${tl[lv.type]||lv.type},,,,,"${note}"\n`;
       }
@@ -4718,7 +4739,7 @@ function exportPDF() {
         doc.text(sh.end, x + 2, y); x += colW[4];
         doc.text(hrs.toFixed(1) + 's', x + 2, y);
       } else if (lv && lv.type) {
-        const tl = {annual:'Yıllık',weekly:'Hafta T.',sick:'Rapor',unpaid:'Ücretsiz'};
+        const tl = {annual:'Yıllık',weekly:'Hafta T.',public_holiday:'R.Tatil',sick:'Rapor',unpaid:'Ücretsiz'};
         doc.text(ds, x + 2, y); x += colW[0];
         doc.text(dayName, x + 2, y); x += colW[1];
         doc.text(tl[lv.type]||lv.type, x + 2, y);
@@ -4842,7 +4863,7 @@ function renderDashTodayWidget() {
   if (tmrSh && tmrSh.start && tmrSh.end) {
     tmrText = `Yarın: ${tmrSh.start}–${tmrSh.end}`;
   } else if (tmrLv && tmrLv.type) {
-    const lb = {annual:'Y.İzin',weekly:'H.Tatil',sick:'Rapor',unpaid:'Ücretsiz'};
+    const lb = {annual:'Y.İzin',weekly:'H.Tatil',public_holiday:'R.Tatil',sick:'Rapor',unpaid:'Ücretsiz'};
     tmrText = `Yarın: ${lb[tmrLv.type] || 'İzin'}`;
   } else { tmrText = 'Yarın: Plan yok'; }
 
@@ -4855,8 +4876,8 @@ function renderDashTodayWidget() {
     sub = `${hrs.toFixed(1)} saat ${hol ? '(Tatil!)' : ''} · ${tmrText}`;
     badge = `${hrs.toFixed(1)}s`;
   } else if (lv && lv.type) {
-    const lb = {annual:'Yıllık İzin',weekly:'Hafta Tatili',sick:'Rapor',unpaid:'Ücretsiz İzin'};
-    const ic = {annual:'🏖️',weekly:'🛋️',sick:'🏥',unpaid:'⛔'};
+    const lb = {annual:'Yıllık İzin',weekly:'Hafta Tatili',public_holiday:'Resmi Tatil',sick:'Rapor',unpaid:'Ücretsiz İzin'};
+    const ic = {annual:'🏖️',weekly:'🛋️',public_holiday:'🏛️',sick:'🏥',unpaid:'⛔'};
     icon = ic[lv.type] || '📋';
     title = `${dayName} — ${lb[lv.type] || 'İzin'}`;
     sub = tmrText;
@@ -5139,6 +5160,19 @@ function generateReportSummary(u, md, earn) {
     msgs.push({ icon:'💪', text:`${streak} günlük aktif seri — harika bir tempo!`, type:'ok' });
   }
 
+  // ⚠️ Yıllık 270 saat FM sınırı (İş Kanunu Madde 41 + Fazla Çalışma Yönetmeliği Md.5)
+  const _now41 = new Date();
+  const _curY41 = _now41.getFullYear();
+  let _yearlyOT = 0;
+  for (let _mi = 0; _mi <= _now41.getMonth(); _mi++) {
+    _yearlyOT += getMD(_curY41, _mi).oh;
+  }
+  if (_yearlyOT >= 270) {
+    msgs.push({ icon:'🚨', text:`Yıllık FM sınırına ulaşıldı! ${_yearlyOT.toFixed(1)}s / 270s — İş Kanunu Md.41 gereği yıllık fazla mesai 270 saati aşamaz.`, type:'warn' });
+  } else if (_yearlyOT >= 240) {
+    msgs.push({ icon:'⚠️', text:`Yıllık FM sınırına yaklaşılıyor: ${_yearlyOT.toFixed(1)}s / 270s (Md.41 — yıllık limit 270s).`, type:'warn' });
+  }
+
   // Veri yoksa genel mesaj
   if (msgs.length === 0) {
     msgs.push({ icon:'📊', text:'Henüz değerlendirme için yeterli veri yok. Vardiya eklemeye devam et!', type:'info' });
@@ -5250,7 +5284,7 @@ function renderDashLast7Days() {
       totalH += hrs; totalD++;
     } else if (lv && lv.type) {
       cls += ' l7-leave';
-      const ic = {annual:'🏖️',weekly:'🛋️',sick:'🏥',unpaid:'⛔'};
+      const ic = {annual:'🏖️',weekly:'🛋️',public_holiday:'🏛️',sick:'🏥',unpaid:'⛔'};
       content = `<div class="l7-ico">${ic[lv.type] || '📋'}</div>`;
     } else if (hol) {
       cls += ' l7-holiday';
@@ -6924,7 +6958,7 @@ function autoLoadHolidays(y, mode) {
     let count = 0;
     holidays.forEach(h => {
       if (u.shifts[h.date] || u.leaves[h.date]) return; // Zaten dolu olan günü atla
-      u.leaves[h.date] = { type: 'weekly', note: 'Resmi Tatil', updatedAt: Date.now() };
+      u.leaves[h.date] = { type: 'public_holiday', note: 'Resmi Tatil', updatedAt: Date.now() };
       if (u.deletedLeaves) delete u.deletedLeaves[h.date];
       count++;
     });
@@ -7005,7 +7039,7 @@ function runCalc() {
   const dr = u.netSalary > 0 ? u.netSalary / 30 : 0;
   const basePay = totalDays * dr;
   const otPay = otHrs * hr * 1.5;
-  const holPay = holWorkedDays * dailyHrs * hr;
+  const holPay = holWorkedDays * dr;  // Md.47: ilave 1 günlük ücret per tatil günü (basePay normal ücreti zaten içeriyor)
   const totalEarn = basePay + otPay + holPay;
 
   const diffMs = toD - fromD;
@@ -7111,8 +7145,8 @@ function renderTeamView() {
         </div>`;
       } else if (lv && lv.type) {
         weekLeaves++;
-        const icons = { annual:'🏖', weekly:'🛋', sick:'🤒', unpaid:'⛔' };
-        const labels = { annual:'Yıllık', weekly:'Tatil', sick:'Rapor', unpaid:'Ücretsiz' };
+        const icons = { annual:'🏖', weekly:'🛋', public_holiday:'🏛', sick:'🤒', unpaid:'⛔' };
+        const labels = { annual:'Yıllık', weekly:'Tatil', public_holiday:'R.Tatil', sick:'Rapor', unpaid:'Ücretsiz' };
         gridHtml += `<div class="tg-cell tg-leave" title="${labels[lv.type]||lv.type}">
           <span>${icons[lv.type]||'📋'}</span>
           <span class="tg-time">${labels[lv.type]||''}</span>


### PR DESCRIPTION
[KRİTİK + ORTA]
- Tatil çalışma ücreti Madde 47 uyumlu hale getirildi: hp = d.hdw × dr (ilave 1 günlük ücret — saatlik değil gün bazlı, basePay ile çift sayma giderildi) calcEarningForMonth, runCalc, updResult güncellendi; display "Xg × dr (Md.47 ilave)"
- monthlyHours varsayılanı 225 → 195 (45s×52.18hf÷12ay, matematiksel doğru) Hint metni Yargıtay 225 seçeneğini de açıklıyor; mevcut kullanıcı ayarları korunuyor

[DÜŞÜK]
- Yıllık 270s FM sınırı (Md.41): generateReportSummary → 240s uyarı, 270s kritik alert
- Zorunlu mola (Md.68): updResult canlı uyarı (mBreakInfo div) + saveEntry warning toast ≤4s→15dk / 4–7.5s→30dk / >7.5s→60dk kuralı uygulandı
- autoLoadHolidays tatil tipi 'weekly' → 'public_holiday' (Md.44 vs Md.47 ayrımı) getMD, yıllık istatistik, takvim ic/lb, _lvA11y, çakışma mesajları, CSV/PDF/takım export dict'leri, dashboard widget'ları güncellendi; wr sayacı her iki tipi de sayıyor

https://claude.ai/code/session_01GLHeGZ3vRiGHBaW2SoUSzT