### PR TITLE
feat: Global polish pack v3.0 — all pages + a11y + motion

### DIFF
--- a/index.html
+++ b/index.html
@@ -1724,6 +1724,854 @@ body.theme-light-ocean #pg-dashboard .card{ border-color:rgba(0,0,0,.07) }
 #pg-dashboard .card-head h3{ font-size:13px; font-weight:800; letter-spacing:-.1px }
 
 /* ===== END DASHBOARD REDESIGN ===== */
+
+/* ================================================================
+   GLOBAL POLISH PACK v3.0 — All remaining pages + a11y + motion
+   ================================================================ */
+
+/* ── Selection & focus (a11y) ──────────────────────────────── */
+::selection { background: rgba(139,92,246,.35); color: #fff }
+body.theme-light ::selection, body.theme-light-ocean ::selection {
+  background: rgba(124,58,237,.2); color: var(--t1);
+}
+:focus-visible {
+  outline: 2px solid var(--p);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+button:focus-visible, .btn:focus-visible, .nav-tab:focus-visible,
+.topbar-btn:focus-visible, .cal-cell:focus-visible {
+  outline: 2px solid var(--p);
+  outline-offset: 2px;
+}
+
+/* ── Global micro-interactions ─────────────────────────────── */
+@keyframes shimmer {
+  0% { background-position: -200% 0 }
+  100% { background-position: 200% 0 }
+}
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(10px) }
+  to { opacity: 1; transform: none }
+}
+@keyframes pulseGlow {
+  0%, 100% { box-shadow: 0 0 0 0 var(--glow2) }
+  50% { box-shadow: 0 0 0 6px transparent }
+}
+
+/* ── Skeleton loader utility ───────────────────────────────── */
+.skeleton {
+  background: linear-gradient(90deg,
+    rgba(255,255,255,.04) 25%,
+    rgba(255,255,255,.08) 50%,
+    rgba(255,255,255,.04) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.6s infinite;
+  border-radius: 8px;
+}
+body.theme-light .skeleton, body.theme-light-ocean .skeleton {
+  background: linear-gradient(90deg,
+    rgba(0,0,0,.05) 25%,
+    rgba(0,0,0,.09) 50%,
+    rgba(0,0,0,.05) 75%);
+  background-size: 200% 100%;
+}
+
+/* ── Empty states ──────────────────────────────────────────── */
+.empty {
+  text-align: center;
+  padding: 48px 20px;
+  color: var(--t3);
+  background: rgba(255,255,255,.015);
+  border-radius: 16px;
+  border: 1px dashed rgba(255,255,255,.08);
+}
+.empty i {
+  font-size: 44px;
+  margin-bottom: 14px;
+  opacity: .3;
+  display: block;
+  background: linear-gradient(135deg, var(--p), var(--p2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  opacity: .45;
+}
+.empty p {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--t2);
+}
+.empty .empty-action { margin-top: 14px }
+body.theme-light .empty, body.theme-light-ocean .empty {
+  background: var(--bg3);
+  border-color: var(--b1);
+}
+
+/* ── Hint box ──────────────────────────────────────────────── */
+.hint {
+  background: rgba(139,92,246,.08);
+  border: 1px solid rgba(139,92,246,.18);
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 12px;
+  color: var(--p3);
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 14px;
+  line-height: 1.5;
+}
+.hint i {
+  margin-top: 2px;
+  font-size: 14px;
+  color: var(--p);
+  flex-shrink: 0;
+}
+
+/* ================================================================
+   LEAVES PAGE
+   ================================================================ */
+.leave-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 14px;
+  margin-bottom: 24px;
+}
+.leave-c {
+  padding: 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(255,255,255,.07);
+  background: var(--card);
+  background-image: linear-gradient(145deg, rgba(255,255,255,.018) 0%, transparent 50%);
+  transition: all .3s cubic-bezier(.16,1,.3,1);
+  position: relative;
+  overflow: hidden;
+}
+.leave-c::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  border-radius: 0;
+}
+.leave-c:nth-child(1)::before { background: linear-gradient(90deg, #60a5fa, #3b82f6) }
+.leave-c:nth-child(2)::before { background: linear-gradient(90deg, #fb923c, #f97316) }
+.leave-c:nth-child(3)::before { background: linear-gradient(90deg, #a78bfa, #8b5cf6) }
+.leave-c:nth-child(4)::before { background: linear-gradient(90deg, #94a3b8, #64748b) }
+.leave-c:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(0,0,0,.28), 0 0 24px var(--glow2);
+  border-color: rgba(139,92,246,.18);
+}
+.leave-c h4 {
+  font-size: 11px;
+  font-weight: 800;
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--t3);
+  text-transform: uppercase;
+  letter-spacing: .5px;
+}
+.leave-c h4 i { font-size: 14px }
+.leave-c .big {
+  font-size: 32px;
+  font-weight: 900;
+  letter-spacing: -1.2px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.leave-c .big small {
+  font-size: 13px;
+  color: var(--t3);
+  font-weight: 700;
+  margin-left: 2px;
+}
+.pbar {
+  height: 6px;
+  background: rgba(255,255,255,.06);
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 12px 0 8px;
+}
+.pbar .pf {
+  height: 100%;
+  border-radius: 4px;
+  transition: width .8s cubic-bezier(.16,1,.3,1);
+}
+.leave-c .meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--t3);
+  font-weight: 600;
+  letter-spacing: .2px;
+}
+body.theme-light .leave-c, body.theme-light-ocean .leave-c {
+  background: var(--card);
+  background-image: none;
+  border-color: rgba(0,0,0,.07);
+}
+.leave-year-nav {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+/* ================================================================
+   STATS PAGE
+   ================================================================ */
+.trend-chart-wrap {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  padding: 10px 0;
+}
+.trend-chart-wrap svg { display: block; width: 100%; overflow: visible }
+.trend-line {
+  fill: none;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 2px 4px rgba(139,92,246,.25));
+}
+.trend-label {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 700;
+  fill: var(--t3);
+  font-size: 10px;
+}
+.trend-val {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-weight: 800;
+  fill: var(--t1);
+}
+.trend-grid {
+  stroke: rgba(255,255,255,.05);
+  stroke-dasharray: 2 4;
+}
+body.theme-light .trend-grid, body.theme-light-ocean .trend-grid {
+  stroke: rgba(0,0,0,.06);
+}
+
+/* ================================================================
+   EARNINGS PAGE
+   ================================================================ */
+.earn-hero {
+  background: linear-gradient(135deg, var(--p2) 0%, #7c3aed 55%, #5b21b6 100%);
+  color: #fff;
+  border-radius: 22px;
+  padding: 32px 30px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 12px 48px rgba(139,92,246,.38), 0 0 0 1px rgba(255,255,255,.08);
+}
+.earn-hero::before {
+  content: '₺';
+  position: absolute;
+  right: 20px;
+  bottom: -30px;
+  font-size: 160px;
+  font-weight: 900;
+  opacity: .08;
+  font-family: system-ui;
+}
+.earn-hero::after {
+  content: '';
+  position: absolute;
+  top: -50px; right: -50px;
+  width: 220px; height: 220px;
+  background: radial-gradient(circle, rgba(255,255,255,.12) 0%, transparent 65%);
+  border-radius: 50%;
+}
+.earn-hero .sub {
+  font-size: 11px;
+  opacity: .7;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .8px;
+  position: relative;
+  z-index: 1;
+}
+.earn-hero .amt {
+  font-size: 42px;
+  font-weight: 900;
+  margin: 8px 0 4px;
+  letter-spacing: -1.5px;
+  font-variant-numeric: tabular-nums;
+  position: relative;
+  z-index: 1;
+}
+.earn-hero .info {
+  font-size: 12px;
+  opacity: .65;
+  font-weight: 600;
+  position: relative;
+  z-index: 1;
+}
+
+/* Earnings sections */
+.earn-section {
+  background: var(--card);
+  border-radius: 18px;
+  padding: 18px 20px;
+  margin-top: 16px;
+  border: 1px solid rgba(255,255,255,.07);
+}
+.earn-section h3 {
+  font-size: 13px;
+  font-weight: 800;
+  color: var(--t1);
+  margin: 0 0 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  letter-spacing: -.1px;
+}
+.earn-section h3 i { color: var(--p); font-size: 14px }
+body.theme-light .earn-section, body.theme-light-ocean .earn-section {
+  background: var(--card);
+  border-color: rgba(0,0,0,.07);
+}
+
+/* Daily grid cells */
+.edg-cell {
+  height: 26px;
+  border-radius: 6px;
+  background: rgba(255,255,255,.04);
+  border: 1px solid rgba(255,255,255,.06);
+  font-size: 9px;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--t3);
+  transition: transform .15s;
+}
+.edg-cell:hover { transform: scale(1.08); z-index: 2 }
+.edg-cell.edg-worked {
+  background: rgba(52,211,153,.12);
+  border-color: rgba(52,211,153,.22);
+  color: var(--g);
+}
+.edg-cell.edg-leave {
+  background: rgba(139,92,246,.12);
+  border-color: rgba(139,92,246,.2);
+  color: var(--p);
+}
+.edg-cell.edg-absent {
+  background: rgba(248,113,113,.1);
+  border-color: rgba(248,113,113,.2);
+  color: var(--r);
+}
+.edg-cell.edg-hol {
+  background: rgba(251,146,60,.12);
+  border-color: rgba(251,146,60,.22);
+  color: #fb923c;
+}
+.edg-cell.edg-ot {
+  background: rgba(251,191,36,.14);
+  border-color: rgba(251,191,36,.24);
+  color: var(--acc);
+}
+
+/* Weekly earning rows */
+.earn-wk-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 0;
+  border-bottom: 1px solid rgba(255,255,255,.04);
+  font-size: 11px;
+}
+.earn-wk-row:last-child { border: none }
+.earn-wk-row .ewk-label {
+  font-weight: 800;
+  color: var(--t3);
+  min-width: 64px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .3px;
+}
+.earn-wk-row .ewk-bar {
+  flex: 1;
+  height: 10px;
+  border-radius: 6px;
+  background: rgba(255,255,255,.05);
+  overflow: hidden;
+}
+.earn-wk-row .ewk-fill {
+  height: 100%;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #7c3aed, #8b5cf6);
+  transition: width .8s cubic-bezier(.16,1,.3,1);
+}
+.earn-wk-row .ewk-val {
+  font-weight: 900;
+  min-width: 72px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+
+/* Shift type earning cards */
+.earn-type-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: rgba(255,255,255,.03);
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,.06);
+  transition: all .2s;
+}
+.earn-type-card:hover {
+  background: rgba(255,255,255,.06);
+  border-color: rgba(139,92,246,.2);
+  transform: translateY(-2px);
+}
+.earn-type-card .etc-icon {
+  font-size: 24px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.earn-type-card .etc-info { flex: 1; min-width: 0 }
+.earn-type-card .etc-name {
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--t1);
+  letter-spacing: -.1px;
+}
+.earn-type-card .etc-detail {
+  font-size: 10px;
+  color: var(--t3);
+  font-weight: 600;
+  margin-top: 2px;
+}
+.earn-type-card .etc-val {
+  font-size: 15px;
+  font-weight: 900;
+  color: var(--g);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Cumul bar */
+.earn-cumul-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 140px;
+  padding: 8px 0 22px;
+}
+.earn-cumul-col {
+  flex: 1;
+  background: linear-gradient(180deg, #8b5cf6, #7c3aed);
+  border-radius: 6px 6px 0 0;
+  position: relative;
+  min-width: 0;
+  cursor: default;
+  transition: filter .2s, transform .2s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  box-shadow: 0 2px 8px rgba(139,92,246,.2);
+}
+.earn-cumul-col:hover {
+  filter: brightness(1.15);
+  transform: scaleY(1.04);
+  transform-origin: bottom;
+}
+.earn-cumul-col .ecl {
+  position: absolute;
+  bottom: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 9px;
+  font-weight: 800;
+  color: var(--t3);
+  white-space: nowrap;
+  letter-spacing: .3px;
+}
+.earn-cumul-col .ecv {
+  font-size: 8px;
+  font-weight: 900;
+  color: #fff;
+  margin-top: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  text-shadow: 0 1px 2px rgba(0,0,0,.3);
+}
+
+/* ================================================================
+   SETTINGS PAGE
+   ================================================================ */
+.s-card {
+  max-width: 640px;
+  margin: 0 auto 16px;
+  background: var(--card);
+  border: 1px solid rgba(255,255,255,.07);
+  border-radius: 20px;
+  padding: 22px 24px;
+  transition: all .3s cubic-bezier(.16,1,.3,1);
+  background-image: linear-gradient(148deg, rgba(255,255,255,.018) 0%, transparent 45%);
+}
+.s-card:hover {
+  border-color: rgba(139,92,246,.15);
+  box-shadow: 0 8px 28px rgba(0,0,0,.25);
+}
+.s-card h3 {
+  font-size: 14px;
+  font-weight: 900;
+  margin-bottom: 18px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid rgba(255,255,255,.05);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  letter-spacing: -.2px;
+}
+.s-card h3 i {
+  color: var(--p);
+  font-size: 15px;
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  background: rgba(139,92,246,.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+body.theme-light .s-card, body.theme-light-ocean .s-card {
+  background: var(--card);
+  background-image: none;
+  border-color: rgba(0,0,0,.07);
+}
+body.theme-light .s-card h3, body.theme-light-ocean .s-card h3 {
+  border-bottom-color: rgba(0,0,0,.06);
+}
+
+.fg { margin-bottom: 14px }
+.fg label {
+  display: block;
+  font-size: 9px;
+  font-weight: 800;
+  color: var(--t3);
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+}
+
+.salary-preview {
+  background: linear-gradient(135deg, rgba(139,92,246,.08), rgba(56,189,248,.05));
+  border: 1px solid rgba(139,92,246,.15);
+  border-radius: 14px;
+  padding: 22px;
+  margin-top: 14px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+.salary-preview::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: var(--pg);
+}
+.salary-preview .amt {
+  font-size: 34px;
+  font-weight: 900;
+  color: var(--p);
+  letter-spacing: -1.5px;
+  font-variant-numeric: tabular-nums;
+}
+.salary-preview .det {
+  font-size: 12px;
+  color: var(--t2);
+  margin-top: 5px;
+  font-weight: 600;
+}
+
+.theme-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.radio-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+.radio-opt {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--t2);
+  cursor: pointer;
+  padding: 9px 14px;
+  background: rgba(255,255,255,.03);
+  border-radius: 10px;
+  border: 1.5px solid rgba(255,255,255,.06);
+  transition: all .2s;
+}
+.radio-opt:hover {
+  border-color: rgba(139,92,246,.2);
+  background: rgba(139,92,246,.05);
+}
+.radio-opt:has(input:checked) {
+  border-color: var(--p);
+  color: var(--t1);
+  background: rgba(139,92,246,.1);
+  box-shadow: 0 0 0 2px rgba(139,92,246,.12);
+}
+.radio-opt input {
+  accent-color: var(--p);
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+}
+body.theme-light .radio-opt, body.theme-light-ocean .radio-opt {
+  background: var(--bg3);
+  border-color: var(--b1);
+}
+.otbal-badge {
+  background: rgba(139,92,246,.1);
+  border: 1px solid rgba(139,92,246,.2);
+  border-radius: 10px;
+  padding: 9px 12px;
+  font-size: 11px;
+  color: var(--t1);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 10px;
+  font-weight: 800;
+}
+
+/* ================================================================
+   DOCUMENTS PAGE
+   ================================================================ */
+.docs-hero {
+  background: linear-gradient(135deg, var(--p2) 0%, #7c3aed 60%, #5b21b6 100%);
+  border-radius: 22px;
+  padding: 24px 26px;
+  margin-bottom: 18px;
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 10px 38px rgba(139,92,246,.3);
+}
+.docs-hero::after {
+  content: '📁';
+  position: absolute;
+  right: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 72px;
+  opacity: .22;
+  filter: drop-shadow(0 4px 12px rgba(0,0,0,.25));
+}
+.docs-hero::before {
+  content: '';
+  position: absolute;
+  right: -40px;
+  top: -40px;
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle, rgba(255,255,255,.12) 0%, transparent 65%);
+  border-radius: 50%;
+}
+.docs-hero h2 {
+  font-size: 20px;
+  font-weight: 900;
+  margin-bottom: 5px;
+  letter-spacing: -.4px;
+  position: relative;
+  z-index: 1;
+}
+.docs-hero p {
+  font-size: 13px;
+  opacity: .85;
+  position: relative;
+  z-index: 1;
+}
+
+.doc-cats {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.doc-cat {
+  padding: 7px 14px;
+  border-radius: 50px;
+  border: 1.5px solid rgba(255,255,255,.08);
+  background: rgba(255,255,255,.03);
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--t2);
+  cursor: pointer;
+  transition: all .2s cubic-bezier(.16,1,.3,1);
+  white-space: nowrap;
+  letter-spacing: .2px;
+}
+.doc-cat:hover {
+  background: rgba(139,92,246,.08);
+  border-color: rgba(139,92,246,.22);
+  color: var(--p3);
+}
+.doc-cat.active {
+  background: linear-gradient(135deg, #7c3aed, #8b5cf6);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 4px 14px rgba(139,92,246,.35);
+}
+body.theme-light .doc-cat, body.theme-light-ocean .doc-cat {
+  background: var(--bg3);
+  border-color: var(--b1);
+}
+
+.docs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(170px, 100%), 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.doc-card {
+  background: var(--card);
+  border: 1px solid rgba(255,255,255,.07);
+  border-radius: 18px;
+  overflow: hidden;
+  transition: all .28s cubic-bezier(.16,1,.3,1);
+  position: relative;
+}
+.doc-card:hover {
+  border-color: rgba(139,92,246,.25);
+  box-shadow: 0 10px 32px rgba(139,92,246,.22);
+  transform: translateY(-3px);
+}
+.doc-thumb {
+  height: 120px;
+  background: linear-gradient(135deg, rgba(139,92,246,.08), rgba(56,189,248,.05));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+.doc-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform .4s cubic-bezier(.16,1,.3,1);
+}
+.doc-card:hover .doc-thumb img { transform: scale(1.06) }
+.doc-thumb .doc-type-icon {
+  font-size: 48px;
+  line-height: 1;
+  filter: drop-shadow(0 4px 8px rgba(0,0,0,.2));
+}
+.doc-thumb .doc-cat-badge {
+  position: absolute;
+  top: 8px; left: 8px;
+  padding: 4px 10px;
+  border-radius: 50px;
+  font-size: 9px;
+  font-weight: 800;
+  background: rgba(0,0,0,.6);
+  color: #fff;
+  backdrop-filter: blur(8px);
+  letter-spacing: .3px;
+  border: 1px solid rgba(255,255,255,.1);
+}
+
+.docs-add-btn {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom,0px) + 76px);
+  right: 18px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #7c3aed, #8b5cf6);
+  color: #fff;
+  border: none;
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 28px rgba(139,92,246,.52), 0 0 0 1px rgba(255,255,255,.1);
+  cursor: pointer;
+  z-index: 90;
+  transition: all .25s cubic-bezier(.16,1,.3,1);
+}
+.docs-add-btn:hover {
+  transform: translateY(-3px) rotate(90deg);
+  box-shadow: 0 12px 36px rgba(139,92,246,.65);
+}
+.docs-add-btn:active { transform: scale(.92) }
+
+/* ================================================================
+   CALENDAR PAGE POLISH
+   ================================================================ */
+.cal-cell.holiday {
+  background: rgba(248,113,113,.07);
+  border-color: rgba(248,113,113,.15);
+}
+.cal-cell.has-shift {
+  background: rgba(52,211,153,.06);
+  border-color: rgba(52,211,153,.13);
+}
+.cal-cell.leave-annual {
+  background: rgba(96,165,250,.09);
+  border-color: rgba(96,165,250,.22);
+}
+.cal-cell.leave-sick {
+  background: rgba(251,146,60,.09);
+  border-color: rgba(251,146,60,.22);
+}
+.cal-cell.leave-unpaid {
+  background: rgba(148,163,184,.09);
+  border-color: rgba(148,163,184,.22);
+}
+.cal-cell.leave-ot_comp {
+  background: rgba(167,139,250,.1);
+  border-color: rgba(167,139,250,.28);
+}
+.cal-cell .leave-label {
+  font-size: 8px;
+  font-weight: 800;
+  padding: 2px 6px;
+  border-radius: 5px;
+  letter-spacing: .2px;
+}
+
+/* ================================================================
+   PAGE TRANSITIONS
+   ================================================================ */
+.page { animation: fadeInUp .4s cubic-bezier(.16,1,.3,1) }
+
+/* ── Prefers-reduced-motion ────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ===== END GLOBAL POLISH PACK v3.0 ===== */
 </style>
 </head>
 <body>


### PR DESCRIPTION
Pages redesigned with premium styling:
- Leaves: colored gradient accents per card (blue/orange/purple/slate), 32px tabular-nums "big" value, 6px rounded progress bars, hover lift
- Stats: drop-shadow on trend-line SVG, dashed grid lines, tabular nums
- Earnings: large gradient hero with ₺ watermark + radial orb, 42px amount, earn-type cards with hover effect, 140px cumul bars with gradient fill + glow, enhanced daily grid cells
- Settings: max-width 640px .s-card with gradient header icon badge, gradient salary-preview with top ribbon, enhanced radio-opt with ring on :checked, theme-picker responsive grid
- Documents: 22px gradient hero with emoji + radial glow, rounded pill doc-cat with gradient active state, 18px doc-card with hover scale image + -3px lift, rotating FAB on hover
- Calendar: refined colored backgrounds for has-shift/holiday/leave states

Global polish:
- Selection color (theme-aware)
- :focus-visible ring for keyboard navigation
- Skeleton loader utility with shimmer animation
- Empty state with gradient text icon + dashed border
- Hint box with glassmorphism
- @media prefers-reduced-motion support
- fadeInUp page transition

All themes preserved (ocean/forest/sunset/rose/gold/light/light-ocean)

https://claude.ai/code/session_01JrLWL53bpbZC111ojmdtrw