### PR TITLE
feat: 7 özel sektör odaklı özellik (2-ajan tartışması sonrası)

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,6 +329,18 @@ body{font-family:'Plus Jakarta Sans',system-ui,sans-serif;background:var(--bg);c
 .dash-today .dt-title{font-size:13px;font-weight:800}
 .dash-today .dt-sub{font-size:11px;opacity:.7;margin-top:2px}
 .dash-today .dt-badge{padding:4px 10px;border-radius:8px;background:rgba(255,255,255,.15);font-size:11px;font-weight:700;white-space:nowrap}
+/* [FEAT F6] Bugün hızlı ekle widget'ı */
+.quick-add-row{background:var(--card);border:1px solid var(--b1);border-radius:var(--rad);padding:12px 14px;margin-bottom:12px}
+.quick-add-row .qa-title{font-size:11px;font-weight:700;color:var(--t2);margin-bottom:8px;display:flex;align-items:center;gap:6px;text-transform:uppercase;letter-spacing:.5px}
+.quick-add-row .qa-title i{color:var(--acc)}
+.quick-add-row .qa-btns{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+.quick-add-btn{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;padding:10px 6px;border-radius:10px;border:1px solid var(--b1);background:var(--bg2);cursor:pointer;transition:transform .12s,border-color .12s,background .12s;color:var(--t1);font-family:inherit;min-height:70px}
+.quick-add-btn:hover{transform:translateY(-1px);border-color:var(--acc);background:var(--bg3)}
+.quick-add-btn:active{transform:translateY(0)}
+.quick-add-btn .qa-ic{font-size:20px;line-height:1}
+.quick-add-btn .qa-lb{font-size:11px;font-weight:700}
+.quick-add-btn .qa-hr{font-size:9px;color:var(--t3);font-variant-numeric:tabular-nums}
+@media (max-width:380px){.quick-add-btn{padding:8px 4px;min-height:62px}.quick-add-btn .qa-ic{font-size:18px}}
 /* Dashboard Progress */
 .dash-progress{background:var(--card);border-radius:var(--rad);padding:14px 16px;margin-bottom:12px;border:1px solid var(--b1)}
 .dash-progress .dp-row{display:flex;align-items:center;gap:10px;margin-bottom:6px}
@@ -392,6 +404,40 @@ body{font-family:'Plus Jakarta Sans',system-ui,sans-serif;background:var(--bg);c
 .earn-type-card .etc-val{font-size:14px;font-weight:900;color:var(--g)}
 .earn-cumul-bar{display:flex;align-items:flex-end;gap:3px;height:120px}
 .earn-cumul-col{flex:1;background:var(--pg);border-radius:4px 4px 0 0;position:relative;min-width:0;cursor:default;transition:opacity .2s,transform .2s;display:flex;flex-direction:column;align-items:center;justify-content:flex-start}
+/* [FEAT F2] Gelir vergisi dilimi kartı */
+.tbc-section .tbc-head{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:14px}
+.tbc-kpi{background:var(--bg3);border:1px solid var(--b1);border-radius:10px;padding:10px 8px;text-align:center}
+.tbc-kpi-v{font-size:15px;font-weight:800;color:var(--t1);font-variant-numeric:tabular-nums}
+.tbc-kpi-l{font-size:10px;color:var(--t3);margin-top:2px;text-transform:uppercase;letter-spacing:.4px;font-weight:700}
+.tbc-steps{display:flex;gap:4px;margin-bottom:10px}
+.tbc-step{flex:1;min-width:0}
+.tbc-step-bar{height:8px;border-radius:4px;background:var(--bg3);overflow:hidden;border:1px solid var(--b1)}
+.tbc-step-fill{height:100%;background:var(--p);transition:width .4s ease}
+.tbc-step.done .tbc-step-fill{background:var(--g)}
+.tbc-step.active .tbc-step-fill{background:linear-gradient(90deg,var(--p),var(--acc))}
+.tbc-step-lbl{display:flex;justify-content:space-between;font-size:9px;font-weight:700;color:var(--t3);margin-top:4px}
+.tbc-step.active .tbc-step-lbl{color:var(--t1)}
+.tbc-note{font-size:12px;color:var(--t2);background:var(--bg3);border-radius:8px;padding:10px 12px;border-left:3px solid var(--acc)}
+.tbc-note b{color:var(--t1)}
+/* [FEAT F5] Zam simülatörü */
+.raise-sim-tabs{display:flex;gap:4px;margin-bottom:12px;background:var(--bg3);padding:3px;border-radius:10px;border:1px solid var(--b1)}
+.rst-tab{flex:1;border:none;background:transparent;padding:8px 4px;font-size:11.5px;font-weight:700;color:var(--t2);cursor:pointer;border-radius:7px;transition:background .15s,color .15s;font-family:inherit}
+.rst-tab.active{background:var(--p);color:#fff}
+.rst-tab:hover:not(.active){background:rgba(255,255,255,.04);color:var(--t1)}
+.raise-sim-result{margin-top:10px}
+.raise-sim-result .rs-empty{font-size:12px;color:var(--t3);font-style:italic;text-align:center;padding:12px}
+.raise-sim-result .rs-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-bottom:10px}
+.raise-sim-result .rs-cell{background:var(--bg3);border:1px solid var(--b1);border-radius:8px;padding:8px 10px}
+.raise-sim-result .rs-l{font-size:10px;color:var(--t3);font-weight:700;text-transform:uppercase;letter-spacing:.3px;margin-bottom:2px}
+.raise-sim-result .rs-v{font-size:14px;font-weight:800;color:var(--t1);font-variant-numeric:tabular-nums}
+.raise-sim-result .rs-diff{background:var(--bg3);border:1px solid var(--b1);border-radius:10px;padding:10px 12px;display:flex;flex-direction:column;gap:6px}
+.raise-sim-result .rs-diff-row{display:flex;justify-content:space-between;align-items:center;font-size:12px;color:var(--t2)}
+.raise-sim-result .rs-diff-row b{font-size:13px;font-variant-numeric:tabular-nums}
+.raise-sim-result .rs-diff-row b.pos{color:var(--g)}
+.raise-sim-result .rs-diff-row b.neg{color:var(--r)}
+.raise-sim-result .rs-diff-row small{opacity:.7;font-weight:700;margin-left:4px}
+.raise-sim-result .rs-note{margin-top:8px;font-size:11.5px;color:var(--t2);background:rgba(14,165,233,.08);border-left:3px solid var(--acc);border-radius:6px;padding:8px 10px}
+.raise-sim-result .rs-note i{color:var(--acc);margin-right:4px}
 .earn-cumul-col:hover{opacity:.9;transform:scaleY(1.03);transform-origin:bottom}
 .earn-cumul-col .ecl{position:absolute;bottom:-16px;left:50%;transform:translateX(-50%);font-size:8px;font-weight:700;color:var(--t3);white-space:nowrap}
 .earn-cumul-col .ecv{font-size:7px;font-weight:800;color:var(--t1);margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
@@ -3002,7 +3048,7 @@ body.theme-light .doc-cat, body.theme-light-ocean .doc-cat {
   <header class="topbar">
     <div class="topbar-brand"><div class="ico"><i class="fas fa-clock"></i></div>ShiftTrack<span class="cloud-user" id="cloudUserInfo"></span></div>
     <div class="topbar-right">
-      <div class="sync-status" id="syncStatus" title="Senkronizasyon durumu"><div class="sync-dot offline" id="syncDot"></div><span id="syncText">Çevrimdışı</span></div>
+      <div class="sync-status" id="syncStatus" title="Dokun: Şimdi senkronize et" onclick="forceSyncNow()" style="cursor:pointer"><div class="sync-dot offline" id="syncDot"></div><span id="syncText">Çevrimdışı</span></div>
       <button class="topbar-btn notif-bell" id="notifBtn" onclick="showNotifications()" title="Bildirimler"><i class="fas fa-bell"></i><span class="notif-badge" id="notifBadge" style="display:none"></span></button>
       <button class="topbar-btn tb-desktop" onclick="showShortcuts()" title="Kısayollar (?)"><i class="fas fa-keyboard"></i></button>
       <button class="topbar-btn tb-desktop" id="undoBtn" disabled onclick="undo()" title="Geri Al (Ctrl+Z)"><i class="fas fa-undo"></i></button>
@@ -3082,7 +3128,8 @@ body.theme-light .doc-cat, body.theme-light-ocean .doc-cat {
         <div><h1>Vardiya Takvimi</h1><p>Güne tıklayarak giriş yapın</p></div>
         <div style="display:flex;gap:6px;flex-wrap:wrap">
           <button class="btn btn-outline btn-sm" onclick="toggleMultiSelect()" id="multiSelBtn"><i class="fas fa-object-group"></i>Çoklu Seç</button>
-          <button class="btn btn-outline btn-sm" onclick="repeatLastWeek()"><i class="fas fa-redo"></i>Haftayı Tekrarla</button>
+          <button class="btn btn-outline btn-sm" onclick="repeatLastWeek()" title="Geçen hafta → bu hafta"><i class="fas fa-redo"></i>Haftayı Tekrarla</button>
+          <button class="btn btn-outline btn-sm" onclick="copyThisWeekToNext()" title="Bu hafta → sonraki hafta"><i class="fas fa-forward"></i>Sonraki Haftaya Kopyala</button>
           <button class="btn btn-soft btn-sm" onclick="goToday()"><i class="fas fa-crosshairs"></i>Bugün</button>
         </div>
       </div>
@@ -3203,6 +3250,22 @@ body.theme-light .doc-cat, body.theme-light-ocean .doc-cat {
         </div>
       </div>
 
+      <!-- [FEAT F5] Zam Simülatörü -->
+      <div class="card s-card">
+        <h3><i class="fas fa-chart-line"></i>Zam Simülatörü</h3>
+        <div class="hint"><i class="fas fa-lightbulb"></i><span>Yüzde veya hedef net maaş girin — brüt/net fark ve yıllık etki anında görünsün.</span></div>
+        <div class="raise-sim-tabs">
+          <button class="rst-tab active" type="button" onclick="rsSwitch('pct')">% Zam</button>
+          <button class="rst-tab" type="button" onclick="rsSwitch('net')">Hedef Net</button>
+          <button class="rst-tab" type="button" onclick="rsSwitch('gross')">Hedef Brüt</button>
+        </div>
+        <div class="fg" id="rsInputWrap">
+          <label id="rsLabel">Zam Oranı (%)</label>
+          <input type="number" id="rsInput" placeholder="25" min="0" step="0.5" oninput="renderRaiseSim()">
+        </div>
+        <div id="rsResult" class="raise-sim-result"></div>
+      </div>
+
       <div class="card s-card">
         <h3><i class="fas fa-calendar-check"></i>Yıllık İzin</h3>
         <div class="fg"><label>İzin Hakkı (gün)</label><input type="number" id="sLeave" placeholder="14" min="0" max="40" onchange="sSet('annualLeave',this.value)"></div>
@@ -3297,6 +3360,7 @@ body.theme-light .doc-cat, body.theme-light-ocean .doc-cat {
           <button class="btn btn-outline" onclick="exportD()"><i class="fas fa-download"></i>Yedekle</button>
           <button class="btn btn-outline" onclick="exportCSV()"><i class="fas fa-file-csv"></i>CSV</button>
           <button class="btn btn-outline" onclick="exportPDF()"><i class="fas fa-file-pdf"></i>PDF</button>
+          <button class="btn btn-outline" onclick="shareMonthReport()"><i class="fas fa-share-alt"></i>Paylaş</button>
           <button class="btn btn-outline" onclick="openQR()"><i class="fas fa-qrcode"></i>QR Transfer</button>
           <button class="btn btn-outline" onclick="document.getElementById('impF').click()"><i class="fas fa-upload"></i>Yükle</button>
           <input type="file" id="impF" style="display:none" accept=".json" onchange="importD(event)">
@@ -3756,6 +3820,23 @@ function getAnnualUsed(uid, yr, excArr) {
     c++;
   });
   return c;
+}
+
+/* [FEAT F3] Yıllık toplam FM (yasal sınır 270s — İş K. Md.41) */
+function getYearlyOT(yr) {
+  let sum = 0;
+  for (let mm = 0; mm < 12; mm++) sum += safeNum(getMD(yr, mm).oh, 0);
+  return sum;
+}
+/* [FEAT F3] Son 3 aylık FM toplamı (Md.41 — 3 ayda 90s önerisi) */
+function getQuarterlyOT(yr, mo) {
+  let sum = 0;
+  for (let i = 0; i < 3; i++) {
+    let mm = mo - i, yy = yr;
+    if (mm < 0) { mm += 12; yy--; }
+    sum += safeNum(getMD(yy, mm).oh, 0);
+  }
+  return sum;
 }
 
 /* ============================================================
@@ -4697,6 +4778,46 @@ function pasteAndClose() {
 
 function clearClipboard() { S.clipboard = null; renderCopyBar(); }
 
+/* [FEAT F1] Bu haftayı bir sonraki haftaya kopyala — "Sonraki Haftaya Kopyala" */
+function copyThisWeekToNext() {
+  const u = cu(); if (!u) return;
+  const today = new Date();
+  const todayDow = today.getDay() === 0 ? 6 : today.getDay() - 1;
+  const thisMonday = new Date(today);
+  thisMonday.setDate(today.getDate() - todayDow);
+  const nextMonday = new Date(thisMonday);
+  nextMonday.setDate(thisMonday.getDate() + 7);
+  const src = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(thisMonday); d.setDate(thisMonday.getDate() + i);
+    const ds = dStr(d);
+    if (u.shifts[ds]) src.push({ dow: i, shift: { ...u.shifts[ds] } });
+    else if (u.leaves[ds]) src.push({ dow: i, leave: { ...u.leaves[ds] } });
+  }
+  if (!src.length) { toast('Bu haftada veri yok', 'error'); return; }
+  const shiftCount = src.filter(s => s.shift).length;
+  showConfirm('Sonraki Haftaya Kopyala', `Bu haftanın ${shiftCount} vardiyası bir sonraki haftaya kopyalanacak. Dolu günler korunur.`, () => {
+    pushUndo('Sonraki haftaya kopyala');
+    let count = 0;
+    src.forEach(item => {
+      const targetDate = new Date(nextMonday);
+      targetDate.setDate(nextMonday.getDate() + item.dow);
+      const ds = dStr(targetDate);
+      if (u.shifts[ds] || u.leaves[ds]) return;
+      if (item.shift) {
+        u.shifts[ds] = { ...item.shift, updatedAt: Date.now() };
+        if (u.deletedShifts) delete u.deletedShifts[ds];
+        count++;
+      } else if (item.leave) {
+        u.leaves[ds] = { ...item.leave, updatedAt: Date.now() };
+        if (u.deletedLeaves) delete u.deletedLeaves[ds];
+      }
+    });
+    invalidateMDCache(); saveLS(); renderActivePage();
+    toast(`${count} vardiya sonraki haftaya kopyalandı`, 'success');
+  });
+}
+
 function repeatLastWeek() {
   const u = cu(); if (!u) return;
   const today = new Date();
@@ -5133,6 +5254,20 @@ function saveEntry() {
       } else {
         toast(`${hrs.toFixed(1)}s kaydedildi`, 'success');
       }
+      /* [FEAT F3] Yasal FM sınırı bildirimi (Md.41) */
+      if (_p) {
+        const yOT = getYearlyOT(_p.y);
+        const qOT = getQuarterlyOT(_p.y, _p.m);
+        if (yOT >= 270) {
+          setTimeout(() => toast(`⚠️ Yıllık FM sınırı aşıldı: ${yOT.toFixed(0)}s / 270s (Md.41)`, 'error'), 600);
+        } else if (yOT >= 240) {
+          setTimeout(() => toast(`⚠️ Yıllık FM sınırına ${(270-yOT).toFixed(0)}s kaldı (${yOT.toFixed(0)}/270s)`, 'warning'), 600);
+        } else if (yOT >= 200) {
+          setTimeout(() => toast(`💡 Yıllık FM: ${yOT.toFixed(0)}s (yasal sınır 270s)`, 'info'), 600);
+        } else if (qOT >= 90) {
+          setTimeout(() => toast(`⚠️ Son 3 ayda FM: ${qOT.toFixed(0)}s (Md.41 — 3 ay 90s önerisi)`, 'warning'), 600);
+        }
+      }
       saveLS(); closeM(); renderActivePage();
     };
 
@@ -5183,6 +5318,17 @@ function saveEntry() {
     if (u.shifts[S.sd]) { if (!u.deletedShifts) u.deletedShifts = {}; u.deletedShifts[S.sd] = Date.now(); }
     delete u.shifts[S.sd];
     toast('Kaydedildi', 'success');
+    /* [FEAT F3] Yıllık izin bakiyesi bildirimi */
+    if (S.lt === 'annual') {
+      const _pl = parseDS(S.sd);
+      if (_pl) {
+        const total = safeInt(u.annualLeave, 14);
+        const used = getAnnualUsed(S.cu, _pl.y);
+        const remain = total - used;
+        if (remain === 0) setTimeout(() => toast('Yıllık izin hakkı bitti (0 gün kaldı)', 'warning'), 500);
+        else if (remain > 0 && remain <= 3) setTimeout(() => toast(`${remain} yıllık izin günü kaldı`, 'warning'), 500);
+      }
+    }
   }
   invalidateMDCache();
   saveLS();
@@ -5647,6 +5793,7 @@ function renderEarn() {
   ${dgHtml}
   ${renderEarnWeekly(u, y, m, d, e)}
   ${renderEarnShiftTypes(u, y, m, e)}
+  ${renderTaxBracketCard(u, y, m)}
   ${renderEarnYearlyCumul(u, y, e)}`;
 
   renderEarnCompare(u, y, m);
@@ -5743,6 +5890,63 @@ function renderEarnShiftTypes(u, y, m, e) {
 }
 
 /* Kazanç — Yıllık Kümülatif Kazanç Grafiği */
+/* [FEAT F2] Kümülatif gelir vergisi dilimi takibi */
+function renderTaxBracketCard(u, y, m) {
+  if (!u.netSalary || u.netSalary <= 0) return '';
+  try {
+    const brackets = payrollConfig.incomeTaxBrackets;
+    let ytdMatrah = 0, monthMatrah = 0;
+    const marital = 'single', children = 0;
+    for (let mi = 0; mi <= m; mi++) {
+      const gross = findGrossFromNet(u.netSalary, marital, children, ytdMatrah);
+      const sgkBase = Math.min(gross, payrollConfig.sgkCeiling);
+      const gvMatrah = gross - sgkBase * (payrollConfig.sgkEmployee + payrollConfig.unemploymentEmployee);
+      ytdMatrah += gvMatrah;
+      if (mi === m) monthMatrah = gvMatrah;
+    }
+    let curIdx = 0, prevUp = 0;
+    for (let i = 0; i < brackets.length; i++) {
+      if (ytdMatrah <= brackets[i].upTo) { curIdx = i; break; }
+      prevUp = brackets[i].upTo;
+      curIdx = i + 1;
+    }
+    const cur = brackets[Math.min(curIdx, brackets.length - 1)];
+    const next = brackets[Math.min(curIdx + 1, brackets.length - 1)];
+    const intoBracket = Math.max(0, ytdMatrah - prevUp);
+    const bracketSize = (cur.upTo === Infinity) ? intoBracket : (cur.upTo - prevUp);
+    const pct = cur.upTo === Infinity ? 100 : Math.min(100, (intoBracket / bracketSize) * 100);
+    const toNext = cur.upTo === Infinity ? 0 : Math.max(0, cur.upTo - ytdMatrah);
+    const monthsToNext = (cur.upTo !== Infinity && monthMatrah > 0) ? Math.ceil(toNext / monthMatrah) : 0;
+
+    const bracketBars = brackets.map((b, i) => {
+      const label = (b.upTo === Infinity) ? '∞' : fm(b.upTo);
+      const state = i < curIdx ? 'done' : i === curIdx ? 'active' : 'pending';
+      return `<div class="tbc-step ${state}" title="${(b.rate*100).toFixed(0)}% · ${label}">
+        <div class="tbc-step-bar"><div class="tbc-step-fill" style="width:${i < curIdx ? 100 : i === curIdx ? pct : 0}%"></div></div>
+        <div class="tbc-step-lbl"><span>%${(b.rate*100).toFixed(0)}</span><span>${label}</span></div>
+      </div>`;
+    }).join('');
+
+    const nextInfo = (cur.upTo === Infinity)
+      ? `<div class="tbc-note">En üst dilimdesin — ek kazançlar %${(cur.rate*100).toFixed(0)} oranında vergilenir.</div>`
+      : `<div class="tbc-note"><b>${fm(toNext)}</b> kümülatif matrah sonra <b>%${(next.rate*100).toFixed(0)}</b> dilimine geçeceksin${monthsToNext > 0 ? ` (~${monthsToNext} ay)` : ''}.</div>`;
+
+    return `<div class="earn-section tbc-section">
+      <h3><i class="fas fa-percentage"></i>Gelir Vergisi Dilimi (${y} Kümülatif)</h3>
+      <div class="tbc-head">
+        <div class="tbc-kpi"><div class="tbc-kpi-v">${fm(ytdMatrah)}</div><div class="tbc-kpi-l">YTD Matrah</div></div>
+        <div class="tbc-kpi"><div class="tbc-kpi-v" style="color:var(--acc)">%${(cur.rate*100).toFixed(0)}</div><div class="tbc-kpi-l">Güncel Oran</div></div>
+        <div class="tbc-kpi"><div class="tbc-kpi-v">${cur.upTo === Infinity ? '—' : fm(toNext)}</div><div class="tbc-kpi-l">Sonraki dilime</div></div>
+      </div>
+      <div class="tbc-steps">${bracketBars}</div>
+      ${nextInfo}
+    </div>`;
+  } catch (err) {
+    console.error('renderTaxBracketCard error:', err);
+    return '';
+  }
+}
+
 function renderEarnYearlyCumul(u, y, e) {
   if (!u.netSalary) return '';
   let cumul = 0, maxCumul = 0;
@@ -6421,6 +6625,65 @@ function toggleNoteEmoji(inputId) {
   inp.parentElement.parentElement.appendChild(picker);
 }
 
+/* [FEAT F5] Zam Simülatörü */
+let _rsMode = 'pct';
+function rsSwitch(mode) {
+  _rsMode = mode;
+  document.querySelectorAll('.rst-tab').forEach(b => b.classList.remove('active'));
+  const tabs = document.querySelectorAll('.rst-tab');
+  const idx = { pct: 0, net: 1, gross: 2 }[mode] ?? 0;
+  if (tabs[idx]) tabs[idx].classList.add('active');
+  const lbl = $('rsLabel'), inp = $('rsInput');
+  if (lbl) lbl.textContent = mode === 'pct' ? 'Zam Oranı (%)' : mode === 'net' ? 'Hedef Net Maaş (₺)' : 'Hedef Brüt Maaş (₺)';
+  if (inp) { inp.value = ''; inp.placeholder = mode === 'pct' ? '25' : mode === 'net' ? '35000' : '45000'; inp.step = mode === 'pct' ? '0.5' : '100'; }
+  const res = $('rsResult'); if (res) res.innerHTML = '';
+}
+function renderRaiseSim() {
+  const u = cu(); const res = $('rsResult'); if (!res) return;
+  if (!u || !u.netSalary || u.netSalary <= 0) { res.innerHTML = '<div class="rs-empty">Önce aylık net maaş girin.</div>'; return; }
+  const inp = $('rsInput'); const raw = inp ? inp.value : '';
+  const val = safeNum(raw, 0);
+  if (!raw || val <= 0) { res.innerHTML = ''; return; }
+  try {
+    const curNet = safeNum(u.netSalary, 0);
+    const curGross = findGrossFromNet(curNet, 'single', 0, 0);
+    let newNet, newGross;
+    if (_rsMode === 'pct') {
+      newNet = curNet * (1 + val / 100);
+      newGross = findGrossFromNet(newNet, 'single', 0, 0);
+    } else if (_rsMode === 'net') {
+      newNet = val;
+      newGross = findGrossFromNet(newNet, 'single', 0, 0);
+    } else {
+      newGross = val;
+      const calc = computeNetFromGross(newGross, 'single', 0, 0);
+      newNet = calc.net;
+    }
+    const diffNet = newNet - curNet;
+    const diffGross = newGross - curGross;
+    const pctNet = curNet > 0 ? (diffNet / curNet * 100) : 0;
+    const pctGross = curGross > 0 ? (diffGross / curGross * 100) : 0;
+    const yearlyNet = diffNet * 12;
+    res.innerHTML = `
+      <div class="rs-grid">
+        <div class="rs-cell"><div class="rs-l">Mevcut Net</div><div class="rs-v">${fm(curNet)}</div></div>
+        <div class="rs-cell"><div class="rs-l">Yeni Net</div><div class="rs-v" style="color:var(--g)">${fm(newNet)}</div></div>
+        <div class="rs-cell"><div class="rs-l">Mevcut Brüt</div><div class="rs-v">${fm(curGross)}</div></div>
+        <div class="rs-cell"><div class="rs-l">Yeni Brüt</div><div class="rs-v" style="color:var(--g)">${fm(newGross)}</div></div>
+      </div>
+      <div class="rs-diff">
+        <div class="rs-diff-row"><span>Net fark</span><b class="${diffNet>=0?'pos':'neg'}">${diffNet>=0?'+':''}${fm(diffNet)} <small>(%${pctNet.toFixed(1)})</small></b></div>
+        <div class="rs-diff-row"><span>Brüt fark</span><b class="${diffGross>=0?'pos':'neg'}">${diffGross>=0?'+':''}${fm(diffGross)} <small>(%${pctGross.toFixed(1)})</small></b></div>
+        <div class="rs-diff-row"><span>Yıllık net etki</span><b class="${yearlyNet>=0?'pos':'neg'}">${yearlyNet>=0?'+':''}${fm(yearlyNet)}</b></div>
+      </div>
+      ${Math.abs(pctNet - pctGross) > 0.5 ? `<div class="rs-note"><i class="fas fa-info-circle"></i> Vergi dilimi etkisi: net zam (%${pctNet.toFixed(1)}) brüt zamdan (%${pctGross.toFixed(1)}) ${pctNet<pctGross?'daha düşük':'daha yüksek'}.</div>` : ''}
+    `;
+  } catch (err) {
+    console.error('renderRaiseSim error:', err);
+    res.innerHTML = '<div class="rs-empty">Hesaplama başarısız.</div>';
+  }
+}
+
 function shareMonthReport() {
   const u = cu(); if (!u) return;
   const md = getMD(S.cy, S.cm);
@@ -6442,14 +6705,42 @@ function shareMonthReport() {
   text += `━━━━━━━━━━━━━━━\n`;
   text += `ShiftTrack Pro`;
 
+  /* [FEAT F4] Web Share API → clipboard fallback → textarea fallback */
+  const title = `${MTR[S.cm]} ${S.cy} Raporu`;
   if (navigator.share) {
-    navigator.share({ title: `${MTR[S.cm]} ${S.cy} Raporu`, text }).catch(() => {});
+    navigator.share({ title, text }).then(
+      () => toast('Rapor paylaşıldı', 'success'),
+      err => {
+        if (err && err.name === 'AbortError') return;
+        _shareFallback(text);
+      }
+    );
   } else {
-    navigator.clipboard.writeText(text).then(() => toast('Rapor kopyalandı!', 'success')).catch(() => {
-      const ta = document.createElement('textarea'); ta.value = text;
-      document.body.appendChild(ta); ta.select(); document.execCommand('copy');
-      document.body.removeChild(ta); toast('Rapor kopyalandı!', 'success');
-    });
+    _shareFallback(text);
+  }
+}
+
+function _shareFallback(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(
+      () => toast('Rapor panoya kopyalandı', 'success'),
+      () => _shareLegacyCopy(text)
+    );
+  } else {
+    _shareLegacyCopy(text);
+  }
+}
+function _shareLegacyCopy(text) {
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text; ta.style.position = 'fixed'; ta.style.left = '-9999px';
+    document.body.appendChild(ta); ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    toast(ok ? 'Rapor panoya kopyalandı' : 'Paylaşım başarısız', ok ? 'success' : 'error');
+  } catch (e) {
+    console.error('share fallback error:', e);
+    toast('Paylaşım başarısız', 'error');
   }
 }
 
@@ -6837,11 +7128,45 @@ function renderDashTodayWidget() {
     badge = 'Boş';
   }
 
+  /* [FEAT F6] Bugün için vardiya yoksa hızlı ekle butonları göster */
+  let quickAdd = '';
+  if (!sh && !lv) {
+    const ps = getAllPresets();
+    const _names = { morning:'Sabah', afternoon:'Öğlen', evening:'Akşam' };
+    const _icons = { morning:'🌅', afternoon:'🌇', evening:'🌙' };
+    const btns = ['morning','afternoon','evening']
+      .filter(k => ps[k])
+      .map(k => `<button class="quick-add-btn" onclick="quickAddToday('${k}')" title="${ps[k].start}–${ps[k].end}"><span class="qa-ic">${_icons[k]}</span><span class="qa-lb">${_names[k]}</span><span class="qa-hr">${ps[k].start}–${ps[k].end}</span></button>`)
+      .join('');
+    quickAdd = `<div class="quick-add-row" data-ds="${ds}"><div class="qa-title"><i class="fas fa-bolt"></i>Bugünü hızlı ekle</div><div class="qa-btns">${btns}</div></div>`;
+  }
   el.innerHTML = `<div class="dash-today">
     <div class="dt-icon">${icon}</div>
     <div class="dt-info"><div class="dt-title">${escHtml(title)}</div><div class="dt-sub">${escHtml(sub)}</div></div>
     <div class="dt-badge">${escHtml(badge)}</div>
-  </div>`;
+  </div>${quickAdd}`;
+}
+
+/* [FEAT F6] Tek dokunuşla bugüne preset vardiya ekle */
+function quickAddToday(presetKey) {
+  const u = cu(); if (!u) return;
+  const ps = getAllPresets();
+  const p = ps[presetKey];
+  if (!p || !p.start || !p.end) { toast('Preset bulunamadı', 'error'); return; }
+  const ds = dStr(new Date());
+  if (u.shifts[ds] || u.leaves[ds]) { toast('Bugün için kayıt zaten var', 'warning'); return; }
+  pushUndo('Hızlı ekle');
+  u.shifts[ds] = {
+    start: p.start,
+    end: p.end,
+    break: safeInt(p.break, 0),
+    note: '',
+    updatedAt: Date.now()
+  };
+  if (u.deletedShifts) delete u.deletedShifts[ds];
+  invalidateMDCache(); saveLS(); renderActivePage();
+  const hrs = calcHr(p.start, p.end, p.break || 0);
+  toast(`Vardiya eklendi: ${p.start}–${p.end} (${hrs.toFixed(1)}s)`, 'success');
 }
 
 /* ============================================================
@@ -8397,12 +8722,52 @@ window.addEventListener('offline', function() {
    SYNC UI
 ============================================================ */
 function setSyncState(state) {
-  const dot = $('syncDot'), txt = $('syncText');
+  const dot = $('syncDot'), txt = $('syncText'), wrap = $('syncStatus');
   if (!dot || !txt) return;
   dot.className = 'sync-dot ' + state;
   const labels = { online:'Senkron', offline:'Çevrimdışı', syncing:'Senkronize ediliyor...', error:'Hata' };
-  txt.textContent = labels[state] || state;
+  let label = labels[state] || state;
+  /* [FEAT F7] Online durumunda son senkron zamanını göster — "Senkron · 2 dk önce" */
+  if (state === 'online' && lastSyncTime > 0) {
+    const mins = Math.floor((Date.now() - lastSyncTime) / 60000);
+    if (mins < 1) label = 'Senkron · az önce';
+    else if (mins < 60) label = `Senkron · ${mins}dk önce`;
+    else label = `Senkron · ${Math.floor(mins/60)}sa önce`;
+  }
+  txt.textContent = label;
+  if (wrap) wrap.title = state === 'error' ? 'Hata: dokun, tekrar dene' : (state === 'offline' ? 'Çevrimdışı' : 'Dokun: Şimdi senkronize et');
 }
+
+/* [FEAT F7] Kullanıcı sync durum bar'ına dokununca manuel senkronizasyon tetikle */
+let _forceSyncBusy = false;
+function forceSyncNow() {
+  if (_forceSyncBusy) return;
+  if (!fbUser || !fbDb) { toast('Önce giriş yapın (Ayarlar → Bulut)', 'warning'); return; }
+  if (syncInProgress) { toast('Senkronizasyon zaten aktif', 'info'); return; }
+  _forceSyncBusy = true;
+  setSyncState('syncing');
+  toast('Senkronizasyon başlatıldı...', 'info');
+  try {
+    pullFromCloud(() => {
+      pushToCloud(() => {
+        _forceSyncBusy = false;
+        toast('Senkronizasyon tamamlandı', 'success');
+      });
+    });
+  } catch (e) {
+    _forceSyncBusy = false;
+    setSyncState('error');
+    toast('Senkronizasyon başarısız', 'error');
+  }
+  /* Güvenlik: 20s sonra flag'i serbest bırak */
+  setTimeout(() => { _forceSyncBusy = false; }, 20000);
+}
+
+/* [FEAT F7] Online iken label'ı periyodik yenile ki "X dk önce" yanıltıcı olmasın */
+setInterval(() => {
+  const dot = $('syncDot');
+  if (dot && dot.classList.contains('online')) setSyncState('online');
+}, 60000);
 
 function updSyncUI() {
   if (fbUser) {


### PR DESCRIPTION
İki ajan (geliştirici + özel sektör son kullanıcı) müzakeresiyle belirlenen 7 özellik eklendi:

F1 Haftayı sonraki haftaya kopyala — tek tıkla takvim şablonu F2 Kümülatif gelir vergisi dilimi kartı — YTD matrah + sonraki dilime uzaklık F3 Yasal FM sınırı + yıllık izin bakiyesi bildirimi (Md.41 270s / 3a 90s) F4 Tek tıkla rapor paylaşımı — Web Share + pano fallback'ları F5 Zam simülatörü — % / net / brüt modları, net-brüt fark + yıllık etki F6 Ana ekran hızlı vardiya widget'ı — bugüne preset tek tıkla ekle F7 Sync güvenilirliği — tıklanabilir durum, "x dk önce" etiketi, manuel senkron

https://claude.ai/code/session_0178LqcBs2kubTnoiEvqH9ae