### PR TITLE
Fix Turkish payroll calculation per official 2026 reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -3709,10 +3709,10 @@ function minuteLabel(mins) {
 }
 function getMonthlyHours(u) {
   const mh = safeNum(u && u.monthlyHours, 0);
-  return mh > 0 ? mh : 195;
+  return mh > 0 ? mh : 225;
 }
 function getStandardDailyHours(u) {
-  return Math.max(1, getMonthlyHours(u) / 26);
+  return Math.max(1, getMonthlyHours(u) / 30);
 }
 function getOTRate(u) {
   return clampNum(u && u.otCompRate, 1.5, 3, 1.5);
@@ -4145,7 +4145,7 @@ function getMD(y, m, opts = {}) {
   const u = cu();
   const dim = new Date(y, m + 1, 0).getDate();
   const throughDay = opts && opts.throughDay !== undefined ? clampInt(opts.throughDay, 0, dim, dim) : null;
-  const empty = { th:0, rh:0, oh:0, hh:0, hhOT:0, hpd:0, wd:0, workDayEquiv:0, hdw:0, wh:{}, wr:0, weeklyRestDays:0, publicHolidayPaidDays:0, ud:0, yau:0, ysd:0, mau:0, msd:0, hr:0, dim, weekTotalHrs:{}, weekMonthOTHrs:{} };
+  const empty = { th:0, rh:0, oh:0, oh125:0, hh:0, hhOT:0, hpd:0, wd:0, workDayEquiv:0, hdw:0, wh:{}, wr:0, weeklyRestDays:0, publicHolidayPaidDays:0, ud:0, yau:0, ysd:0, mau:0, msd:0, hr:0, dim, weekTotalHrs:{}, weekMonthOTHrs:{} };
   if (!u) return empty;
 
   const ck = `${S.cu}-${y}-${m}-${throughDay === null ? 'all' : throughDay}`;
@@ -4153,7 +4153,9 @@ function getMD(y, m, opts = {}) {
 
   let th = 0, hh = 0, hpd = 0;
   const _mh = getMonthlyHours(u);
-  const standardDailyHours = Math.max(1, _mh / 26);
+  const standardDailyHours = Math.max(1, _mh / 30);
+  // [FIX] Sözleşmesel haftalık saat (<45) — fazla çalışma %25 zam, fazla mesai %50 zam ayrımı (4857/41/4)
+  const weeklyContractHours = clampNum(u && u.weeklyContractHours, 1, 45, 45);
 
   // Bu aydaki her gün için: hangi ISO haftasında, kaç saat, tatil mi?
   // dayData[isoWeek] = { monthHrs, monthHolHrs }
@@ -4162,7 +4164,8 @@ function getMD(y, m, opts = {}) {
   const weekTotalHrs = {};  // isoWeek -> tüm hafta boyunca toplam (diğer aylar dahil)
   const weekTotalHolHrs = {}; // isoWeek -> tüm hafta tatil saatleri
   const weekMonthRegularHrs = {};
-  const weekMonthOTHrs = {};
+  const weekMonthOTHrs = {};        // %50 zamlı (haftalık 45 saat üstü)
+  const weekMonthOT125Hrs = {};     // %25 zamlı (sözleşme saati .. 45 arası, fazla çalışma)
   const weekMonthHolOTHrs = {};
   const allParts = [];
   const workedStartDates = new Set();
@@ -4217,18 +4220,25 @@ function getMD(y, m, opts = {}) {
   // (aynı ISO haftasına düşen diğer ayların günlerini de tara)
   const weeksInMonth = Object.keys(weekMonthHrs);
   for (const wk of weeksInMonth) {
-    let totalH = 0, totalHolH = 0, normalLeft = 45;
+    let totalH = 0, totalHolH = 0;
+    let regularLeft = weeklyContractHours;        // sözleşmesel saate kadar normal
+    let partialLeft = Math.max(0, 45 - weeklyContractHours); // sözleşme..45 arası %25 zam
     allParts.filter(part => part.wk === wk).forEach(part => {
-      const hrs = part.hours;
-      const regular = Math.min(hrs, Math.max(0, normalLeft));
-      const overtime = Math.max(0, hrs - regular);
-      normalLeft = Math.max(0, normalLeft - regular);
+      let hrs = part.hours;
+      const regular = Math.min(hrs, Math.max(0, regularLeft));
+      regularLeft = Math.max(0, regularLeft - regular);
+      hrs -= regular;
+      const partialOT = Math.min(hrs, Math.max(0, partialLeft));
+      partialLeft = Math.max(0, partialLeft - partialOT);
+      hrs -= partialOT;
+      const overtime = Math.max(0, hrs); // 45 saat üstü, %50 zam
       const pp = parseDS(part.ds);
       const inTargetMonth = pp && pp.y === y && pp.m === m;
-      totalH += hrs;
-      if (isH(part.ds)) totalHolH += hrs;
+      totalH += part.hours;
+      if (isH(part.ds)) totalHolH += part.hours;
       if (inTargetMonth) {
         weekMonthRegularHrs[wk] = (weekMonthRegularHrs[wk] || 0) + regular;
+        weekMonthOT125Hrs[wk] = (weekMonthOT125Hrs[wk] || 0) + partialOT;
         weekMonthOTHrs[wk] = (weekMonthOTHrs[wk] || 0) + overtime;
         if (isH(part.ds)) weekMonthHolOTHrs[wk] = (weekMonthHolOTHrs[wk] || 0) + overtime;
       }
@@ -4238,9 +4248,10 @@ function getMD(y, m, opts = {}) {
   }
 
   // FM hesabı: ISO hafta içinde gün sırasına göre 45 saat dolduktan sonra yazılır.
-  let oh = 0, rh = 0, hhOT = 0;
+  let oh = 0, oh125 = 0, rh = 0, hhOT = 0;
   for (const wk of weeksInMonth) {
     rh += weekMonthRegularHrs[wk] || 0;
+    oh125 += weekMonthOT125Hrs[wk] || 0;
     oh += weekMonthOTHrs[wk] || 0;
     hhOT += weekMonthHolOTHrs[wk] || 0;
   }
@@ -4272,7 +4283,7 @@ function getMD(y, m, opts = {}) {
   const workDayEquiv = workStartDayEquiv;
   // wh: dashboard haftalık chart için — bu aydaki saatler (görüntüleme amaçlı)
   const wh = weekMonthHrs;
-  const r = { th, rh, oh, hh, hhOT, hpd, wd, workDayEquiv, hdw, wh, wr, weeklyRestDays, publicHolidayPaidDays, ud, otcm, yau, ysd, mau, msd, hr, dim,
+  const r = { th, rh, oh, oh125, hh, hhOT, hpd, wd, workDayEquiv, hdw, wh, wr, weeklyRestDays, publicHolidayPaidDays, ud, otcm, yau, ysd, mau, msd, hr, dim,
     weekTotalHrs, weekMonthOTHrs }; // chart'ta gerçek haftalık toplamı göstermek için
   mdCache[ck] = r;
   return r;
@@ -11080,7 +11091,10 @@ const payrollConfig = {
     { upTo: Infinity,rate: 0.40 },
   ],
   stampTaxRate: 0.00759,          // Damga vergisi %0.759
-  otMultiplier: 1.5,
+  otMultiplier: 1.5,              // Fazla mesai (haftalık 45 saat üstü) zam katsayısı
+  otPartialMultiplier: 1.25,      // Fazla çalışma (haftalık <45 saat sözleşme) zam katsayısı (4857/41/4)
+  monthlyStandardHours: 225,      // Aylık yasal standart saat (30 gün × 7,5 saat) — Yargıtay 9.HD yerleşik içtihat
+  dailyStandardHours: 7.5,        // Yasal günlük çalışma süresi (4857/63)
   mealDailyTaxFree: 300,          // 2026 yemek yardımı günlük vergisiz limit (TL)
   transportDailyTaxFree: 158,     // 2026 yol yardımı günlük vergisiz limit (TL)
 };
@@ -11244,18 +11258,32 @@ function renderBordroPreview() {
   const d = getMD(y, m, (y === now.getFullYear() && m === now.getMonth()) ? { throughDay:now.getDate() } : undefined);
   const mh = getMonthlyHours(u);
   const compRate = getOTRate(u);
+  const partialRate = payrollConfig.otPartialMultiplier; // %25 zam (sözleşme <45 saat)
   const compMode = (u && u.otCompMode) || 'pay';
   const hrGross  = baseGross / mh;   // brüt saatlik ücret
   const drGross  = baseGross / 30;   // brüt günlük ücret
   // FM brüt eki: sadece "pay" modunda ödenir (izin modunda bordro etkisi yok)
-  const otGross  = compMode === 'pay' ? d.oh * hrGross * compRate : 0;
+  const otGross    = compMode === 'pay' ? (d.oh    || 0) * hrGross * compRate    : 0;
+  const ot125Gross = compMode === 'pay' ? (d.oh125 || 0) * hrGross * partialRate : 0;
   // Tatil çalışması ilave ücreti — yarım gün resmi tatiller 0.5 gün sayılır.
   const holPayDays = d.hpd !== undefined ? d.hpd : d.hdw;
   const holGross = holPayDays * drGross;
-  const totalGross = baseGross + otGross + holGross;
+  const totalGross = baseGross + otGross + ot125Gross + holGross;
 
   // 3) Toplam brüt üzerinden vergi/kesinti hesabı
   const res = computeNetFromGross(totalGross, marital, children, priorYTD, m);
+
+  // [FIX] Kümülatif matrah otomatik aktarımı: sonraki ayın priorYTD alanı boşsa, bu ayın ytdMatrah'ını yaz.
+  // Kullanıcı manuel girdiği değerlerin üzerine yazmayız.
+  if (u && m < 11) {
+    const nextRec = getPayrollCheck(u, y, m + 1);
+    if (!nextRec.priorYTD || nextRec.priorYTD <= 0) {
+      nextRec.priorYTD = +res.ytdMatrah.toFixed(2);
+      nextRec.priorYTDAuto = true;
+      nextRec.updatedAt = Date.now();
+      try { saveLS(); } catch(e) { /* yoksay */ }
+    }
+  }
 
   // Vergiden muaf yan haklar
   const mealTotal      = mealDays * payrollConfig.mealDailyTaxFree;
@@ -11266,8 +11294,9 @@ function renderBordroPreview() {
   _eBordroSession.result = {
     ...res, mealTotal, transportTotal, finalNet, marital, children, priorYTD, y, m,
     userId:S.cu,
-    baseGross, otGross, holGross, totalGross,
-    otHours: d.oh, holDays: d.hdw, holPayDays, hrGross, drGross, compRate,
+    baseGross, otGross, ot125Gross, holGross, totalGross,
+    otHours: d.oh, ot125Hours: d.oh125 || 0, holDays: d.hdw, holPayDays, hrGross, drGross, compRate, partialRate,
+    annualLeaveDays: d.mau || 0, sickLeaveDays: d.msd || 0, unpaidDays: d.ud || 0,
     empName:  (($('eb-empName')  || {}).value || '').slice(0, 120),
     company:  (($('eb-company')  || {}).value || '').slice(0, 120),
     tcNo:     (($('eb-tcNo')     || {}).value || '').replace(/\D/g, '').slice(0, 11),
@@ -11276,7 +11305,10 @@ function renderBordroPreview() {
 
   const fmb = v => v.toLocaleString('tr-TR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' ₺';
   const fmr = v => v.toLocaleString('tr-TR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-  const hasExtras = otGross > 0 || holGross > 0;
+  const hasExtras = otGross > 0 || ot125Gross > 0 || holGross > 0;
+  const annualLeaveDays = d.mau || 0;
+  const sickLeaveDays = d.msd || 0;
+  const unpaidDays = d.ud || 0;
 
   const previewEl = $('bordroPreview');
   if (!previewEl) return;
@@ -11285,7 +11317,11 @@ function renderBordroPreview() {
       <i class="fas fa-file-invoice"></i> BORDRO ÖNİZLEME — ${MTR[m].toUpperCase()} ${y}
     </div>
     <div class="bordro-row"><span class="bl">Temel Brüt Maaş</span><span class="bv">${fmb(baseGross)}</span></div>
-    ${otGross > 0 ? `<div class="bordro-row add"><span class="bl">FM Ücreti (${d.oh.toFixed(1)}s × ${fmr(hrGross)}₺ × ${compRate})</span><span class="bv">+ ${fmb(otGross)}</span></div>` : ''}
+    ${annualLeaveDays > 0 ? `<div class="bordro-row info"><span class="bl">Yıllık İzin (ücretli, baz içinde)</span><span class="bv">${fmr(annualLeaveDays)} gün</span></div>` : ''}
+    ${sickLeaveDays > 0 ? `<div class="bordro-row info"><span class="bl">Raporlu / İstirahat (SGK ödemesi ayrı)</span><span class="bv">${fmr(sickLeaveDays)} gün</span></div>` : ''}
+    ${unpaidDays > 0 ? `<div class="bordro-row deduct"><span class="bl">Ücretsiz İzin (baz brütten düşülür)</span><span class="bv">− ${fmb(unpaidDays * drGross)}</span></div>` : ''}
+    ${ot125Gross > 0 ? `<div class="bordro-row add"><span class="bl">Fazla Çalışma %25 (${(d.oh125||0).toFixed(1)}s × ${fmr(hrGross)}₺ × ${partialRate})</span><span class="bv">+ ${fmb(ot125Gross)}</span></div>` : ''}
+    ${otGross > 0 ? `<div class="bordro-row add"><span class="bl">Fazla Mesai %50 (${d.oh.toFixed(1)}s × ${fmr(hrGross)}₺ × ${compRate})</span><span class="bv">+ ${fmb(otGross)}</span></div>` : ''}
     ${holGross > 0 ? `<div class="bordro-row add"><span class="bl">Tatil Çalışması İlavesi — ${fmr(holPayDays)}g × ${fmr(drGross)}₺ (Md.47)</span><span class="bv">+ ${fmb(holGross)}</span></div>` : ''}
     ${hasExtras ? `<div class="bordro-row sub"><span class="bl">TOPLAM BRÜT</span><span class="bv">${fmb(totalGross)}</span></div>` : ''}
     <div class="bordro-row deduct"><span class="bl">SGK İşçi Payı (%14)</span><span class="bv">− ${fmb(res.sgkDeduction)}</span></div>
@@ -11351,9 +11387,10 @@ function downloadBordroPDF() {
   const rows = [
     ['TEMEL BRUT MAAS', fmb(r.baseGross || r.gross), ''],
   ];
-  if (r.otGross > 0)  rows.push([`FM Ucreti (${(r.otHours||0).toFixed(1)}s x ${(r.hrGross||0).toFixed(2)} x ${r.compRate||1.5})`, fmb(r.otGross), '']);
+  if (r.ot125Gross > 0) rows.push([`Fazla Calisma %25 (${(r.ot125Hours||0).toFixed(1)}s x ${(r.hrGross||0).toFixed(2)} x ${r.partialRate||1.25})`, fmb(r.ot125Gross), '']);
+  if (r.otGross > 0)  rows.push([`Fazla Mesai %50 (${(r.otHours||0).toFixed(1)}s x ${(r.hrGross||0).toFixed(2)} x ${r.compRate||1.5})`, fmb(r.otGross), '']);
   if (r.holGross > 0) rows.push([`Tatil Cal. Ilavesi (${(r.holPayDays||r.holDays||0).toFixed(2)}g x ${(r.drGross||0).toFixed(2)}) Md.47`, fmb(r.holGross), '']);
-  if (r.otGross > 0 || r.holGross > 0) rows.push(['TOPLAM BRUT', fmb(r.gross), '']);
+  if (r.otGross > 0 || r.ot125Gross > 0 || r.holGross > 0) rows.push(['TOPLAM BRUT', fmb(r.gross), '']);
   rows.push(
     ['SGK Isci Payi (%14)',    '',                     fmb(r.sgkDeduction)],
     ['Issizlik Sigortasi (%1)','',                     fmb(r.unemployDeduct)],
@@ -11422,13 +11459,18 @@ function exportBordroJSON() {
     earnings: {
       baseGross:          +(r.baseGross || r.gross).toFixed(2),
       overtimePay:        +(r.otGross   || 0).toFixed(2),
+      partialOvertimePay: +(r.ot125Gross || 0).toFixed(2),
       holidayWorkPay:     +(r.holGross  || 0).toFixed(2),
       totalGross:         +r.gross.toFixed(2),
       mealAllowance:      +r.mealTotal.toFixed(2),
       transportAllowance: +r.transportTotal.toFixed(2),
       otHours:            +(r.otHours   || 0).toFixed(2),
+      ot125Hours:         +(r.ot125Hours || 0).toFixed(2),
       holDays:            r.holDays    || 0,
       holPayDays:         +(r.holPayDays || r.holDays || 0).toFixed(2),
+      annualLeaveDays:    r.annualLeaveDays || 0,
+      sickLeaveDays:      r.sickLeaveDays || 0,
+      unpaidDays:         r.unpaidDays || 0,
     },
     deductions: {
       sgkEmployee:   +r.sgkDeduction.toFixed(2),
@@ -11478,7 +11520,8 @@ function exportBordroXML() {
   </Calisan>
   <Kazanclar>
     <TemelBrutMaas>${fv(r.baseGross || r.gross)}</TemelBrutMaas>
-    <FazlaMesaiUcreti saat="${(r.otHours||0).toFixed(2)}">${fv(r.otGross||0)}</FazlaMesaiUcreti>
+    <FazlaCalismaYuzde25 saat="${(r.ot125Hours||0).toFixed(2)}" oran="${r.partialRate||1.25}" kanun="4857/41/4">${fv(r.ot125Gross||0)}</FazlaCalismaYuzde25>
+    <FazlaMesaiUcreti saat="${(r.otHours||0).toFixed(2)}" oran="${r.compRate||1.5}">${fv(r.otGross||0)}</FazlaMesaiUcreti>
     <TatilCalismasiIlavesi gun="${r.holPayDays||r.holDays||0}" takvimGunu="${r.holDays||0}" kanun="Md.47">${fv(r.holGross||0)}</TatilCalismasiIlavesi>
     <ToplamBrut>${fv(r.gross)}</ToplamBrut>
     <YemekYardimi>${fv(r.mealTotal)}</YemekYardimi>


### PR DESCRIPTION
- getMonthlyHours default 195→225 (30×7.5, Yargıtay 9.HD yerleşik içtihat); saatlik ücret artık 1930.31/7.5=257.375 ₺ ile eşleşiyor
- getStandardDailyHours: /26 → /30 (yasal 30 gün tahakkuk üzerinden)
- payrollConfig: monthlyStandardHours=225, dailyStandardHours=7.5, otPartialMultiplier=1.25 (4857/41/4 fazla çalışma %25 zam)
- getMD(): haftalık FM ayrımı — sözleşmesel saat (<45) ile 45 arası oh125 (%25), 45 üstü oh (%50) olarak ayrı tutulur
- renderBordroPreview: oh125 için ayrı satır; yıllık izin/raporlu/ücretsiz izin gün gösterimi; sonraki ayın priorYTD'sine kümülatif matrah otomatik aktarımı (manuel girdiyi ezmez)
- PDF/JSON/XML export: oh125, ot125Hours, izin günleri eklendi