### PR TITLE
fix: [BLOKE-01] shift-priority kontrolünü yıllık sayaçların önüne taşı

### DIFF
--- a/index.html
+++ b/index.html
@@ -4738,6 +4738,9 @@ function getMD(y, m, opts = {}) {
   Object.entries(u.leaves).forEach(([k, v]) => {
     const p = parseDS(k); if (!p || !v || !v.type) return;
     const withinCutoff = throughDay === null || p.y !== y || p.m !== m || p.d <= throughDay;
+    /* [FIX BLOKE-01] Import/merge çakışması: aynı gün hem shift hem leave olursa
+       shift öncelikli — yıllık (yau/ysd) ve aylık sayaçların tümünü atla. */
+    if (u.shifts && u.shifts[k]) return;
     if (p.y === y && withinCutoff) { if (v.type === 'annual') yau++; if (v.type === 'sick') ysd++; }
     if (p.y === y && p.m === m) {
       if (!withinCutoff) return;


### PR DESCRIPTION
Aynı gün hem shift hem leave kaydı olduğunda leave döngüsündeki erken çıkış yalnızca aylık sayaçları (mau/msd) atlıyordu; yau/ysd yıllık bakiyeler önceki satırda zaten arttırılmıştı. Kontrol `withinCutoff` hesabından hemen sonraya (yıllık artışların önüne) taşındı; böylece çakışma günleri hem aylık hem yıllık izin bakiyesini etkilemez.

https://claude.ai/code/session_01DQURCaCx6ScX85bpoZohjW