### PR TITLE
fix: FM formül gösterimi brüt saatlik ücret kullanacak şekilde düzelt…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4828,7 +4828,7 @@ function calcEarningForMonth(y, m, ns) {
 
   if (isFut) {
     return {
-      dailyRate: dr, hourlyRate: hr,
+      dailyRate: dr, hourlyRate: hr, hourlyRateGross: hrGross,
       basePay: 0, overtimePay: 0, overtimePay125: 0, holidayPay: 0, totalEarning: 0,
       paidDays: 0, workedDays: d.wd || 0, workPaidDays: d.workDayEquiv || 0, weeklyDays: d.wr || 0,
       annualDays: d.mau || 0, sickDays: d.msd || 0, unpaidDays: d.ud || 0, otCompDays: d.otcm || 0,
@@ -4888,7 +4888,7 @@ function calcEarningForMonth(y, m, ns) {
   const te = Number.isFinite(teRaw) ? Math.max(0, teRaw) : 0;
 
   return {
-    dailyRate: dr, hourlyRate: hr,
+    dailyRate: dr, hourlyRate: hr, hourlyRateGross: hrGross,
     basePay: bp, overtimePay: op, overtimePay125: op125, holidayPay: hp, totalEarning: te,
     paidDays: Math.round(pd * 100) / 100, workedDays: d.wd, workPaidDays: Math.round(workPaidDays * 100) / 100, weeklyDays: d.wr,
     annualDays: d.mau, sickDays: d.msd, unpaidDays: d.ud, otCompDays: d.otcm || 0,
@@ -7154,11 +7154,11 @@ function renderEarn() {
       ` : ''}
       ${e.overtimePay > 0 ? `
       <div class="esd-head" style="color:#f97316">🔥 FAZLA MESAİ (${getOTRate(u)}×)</div>
-      <div class="esd"><span class="ek">${e.overtimeHours.toFixed(1)}s × ${fm(e.hourlyRate)} × ${getOTRate(u)}</span><span class="ev pos">+${fm(e.overtimePay)}</span></div>
+      <div class="esd"><span class="ek">${e.overtimeHours.toFixed(1)}s × ${fm(e.hourlyRateGross || e.hourlyRate)} (brüt) × ${getOTRate(u)}</span><span class="ev pos">+${fm(e.overtimePay)}</span></div>
       ` : ''}
       ${(e.overtimePay125 || 0) > 0 ? `
       <div class="esd-head" style="color:#fb923c">⚡ FAZLA SÜRELERLE ÇALIŞMA (${e.partialRate || 1.25}×)</div>
-      <div class="esd"><span class="ek">${(e.overtimeHours125||0).toFixed(1)}s × ${fm(e.hourlyRate)} × ${e.partialRate || 1.25}</span><span class="ev pos">+${fm(e.overtimePay125)}</span></div>
+      <div class="esd"><span class="ek">${(e.overtimeHours125||0).toFixed(1)}s × ${fm(e.hourlyRateGross || e.hourlyRate)} (brüt) × ${e.partialRate || 1.25}</span><span class="ev pos">+${fm(e.overtimePay125)}</span></div>
       ` : ''}
       ${e.holidayPay > 0 ? `
       <div class="esd-head" style="color:var(--g)">🏛️ TATİL PRİMLERİ</div>


### PR DESCRIPTION
…ildi

Fazla mesai (ve fazla sürelerle çalışma) hesabı 4857/41 gereği brüt saatlik ücret üzerinden yapılıyor (hrGross), ancak formül etiketi net saatlik ücreti (hr) gösteriyordu. Bu durum kullanıcıya matematiksel olarak tutarsız görünen bir denklem (ör. 12 × 184 × 1.5 = 4.133 ≠ 3.312) sunuyordu. hourlyRateGross earning objesine eklendi ve display satırlarında (7157, 7161) net yerine brüt oran gösterildi.

https://claude.ai/code/session_01KFPRqkMsp5z6fDtnCjDxjg