### PR TITLE
fix: baz ücret gerçek ay gün sayısı ve tatil primi net günlük ücret k…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4855,26 +4855,14 @@ function calcEarningForMonth(y, m, ns) {
   const pd = workPaidDays + d.wr + d.mau + d.msd + (d.otcm || 0);
   const mis = Math.max(0, ev - pd - d.ud - fp);
   const ab = d.ud + mis;
-  const bp = Math.max(0, ns - (ab * dr));
+  /* Günlük (G) sözleşmelerde gerçek ay gün sayısı üzerinden baz ücret hesaplanır.
+     Ocak (31g) → 31×dr, Şubat (28g) → 28×dr. Aylık sabit için 30-günlük ayda fark yok. */
+  const bp = Math.max(0, dim * dr - (ab * dr));
 
-  /* [FIX Md.47 + P7] Tatil çalışması ilave ücreti: basePay içinde normal tatil ücreti var;
-     Madde 47 gereği ilave 1 günlük BRÜT ücret ödenir. Bu ekran "TAHMİNİ NET" gösterdiği için
-     brüt ek ücretin marjinal vergi/SGK sonrası net karşılığını hesaplıyoruz. */
+  /* Md.47 tatil ilave ücreti = 1 günlük NET ücret (dr). Bordro doğrulaması:
+     brüt extra (₺1.930,31) → marjinal vergi/SGK sonrası net = tam ₺1.380 = dr. */
   const _hpd = (d.hpd !== undefined ? d.hpd : d.hdw) || 0;
-  let hp;
-  if (_hpd > 0 && Number.isFinite(ns) && ns > 0) {
-    const _cfgHp = payrollCfg(y);
-    const _fullGross = findGrossFromNet(ns, 'single', 0, 0, m, undefined, y);
-    const _dailyGross = _fullGross / 30;
-    const _sgkRate = _cfgHp.sgkEmployee + _cfgHp.unemploymentEmployee; // 0.15
-    const _approxYTD = ns * (m + 1); // yaklaşık net YTD (dilim tahmini)
-    const _gvRate = _bracketRateFor(_approxYTD, y);
-    const _stamp = _cfgHp.stampTaxRate;
-    const _netRatio = (1 - _sgkRate) * (1 - _gvRate) - _stamp;
-    hp = _hpd * _dailyGross * Math.max(0.4, Math.min(1, _netRatio));
-  } else {
-    hp = _hpd * dr; // fallback (eski davranış)
-  }
+  const hp = _hpd * dr;
   /* [FIX] otCompMode: 'leave' modunda FM eki ödenmez, saatler bakiyeye eklenir */
   const compMode = u.otCompMode || 'pay';
   const compRate = getOTRate(u);
@@ -4891,7 +4879,7 @@ function calcEarningForMonth(y, m, ns) {
   return {
     dailyRate: dr, hourlyRate: hr, hourlyRateGross: hrGross, dailyRateGross: _fullGrossForOT > 0 ? _fullGrossForOT / 30 : dr,
     basePay: bp, overtimePay: op, overtimePay125: op125, holidayPay: hp, totalEarning: te,
-    paidDays: Math.round(pd * 100) / 100, workedDays: d.wd, workPaidDays: Math.round(workPaidDays * 100) / 100, weeklyDays: d.wr,
+    paidDays: Math.round((dim - ab) * 100) / 100, workedDays: d.wd, workPaidDays: Math.round(workPaidDays * 100) / 100, weeklyDays: d.wr,
     annualDays: d.mau, sickDays: d.msd, unpaidDays: d.ud, otCompDays: d.otcm || 0,
     missingDays: mis, absentDays: ab, freePassDays: fp,
     dim, totalHours: d.th, overtimeHours: d.oh, overtimeHours125: d.oh125 || 0,
@@ -7163,7 +7151,7 @@ function renderEarn() {
       ` : ''}
       ${e.holidayPay > 0 ? `
       <div class="esd-head" style="color:var(--g)">🏛️ TATİL PRİMLERİ</div>
-      <div class="esd"><span class="ek">${(e.holidayPayDays || e.holidayDays).toFixed(1)}g tatil × ${fm(e.dailyRateGross || e.dailyRate)} (brüt günlük) ilave (Md.47, marjinal vergi sonrası net)</span><span class="ev pos">+${fm(e.holidayPay)}</span></div>
+      <div class="esd"><span class="ek">${(e.holidayPayDays || e.holidayDays).toFixed(1)}g tatil × ${fm(e.dailyRate)} ilave (Md.47)</span><span class="ev pos">+${fm(e.holidayPay)}</span></div>
       ${(e.hhOT||0) > 0 ? `<div class="esd" style="color:var(--acc);font-size:11px"><span class="ek" style="padding-left:8px">↳ ${e.hhOT.toFixed(1)}s tatil çalışması haftalık 45'i aşıyor; FM zammı ve Md.47 günlük ek ayrı satırlarda uygulanır.</span><span class="ev"></span></div>` : ''}
       ` : ''}
       <div class="esd total"><span class="ek"><i class="fas fa-wallet"></i><b>TAHMİNİ NET</b></span><span class="ev">${fm(e.totalEarning)}</span></div>


### PR DESCRIPTION
…ullanacak şekilde düzeltildi

Ocak 2026 bordrosu karşılaştırmasıyla iki tutarsızlık tespit edildi:

1. Baz maaş: Uygulama sabit 30-gün (₺41.400) hesaplarken ÜCRET PERİYO:G (Günlük) sözleşmede Ocak 31 gün × ₺1.380 = ₺42.780 olmalıydı. bp = ns - ab×dr → bp = dim×dr - ab×dr (gerçek ay günü baz)

2. Tatil primi (Md.47): Karmaşık brüt→net dönüşümü ₺1.231 veriyordu.
   Bordro doğrulaması: brüt ₺1.930,31 → marjinal kesinti → net = tam ₺1.380 = dr.
   Sonuç: hp = _hpd × dr (günlük net ücret) yeterliydi.

İki düzeltme birlikte: tahmin ₺42.631 → ₺44.160 (bordroyla sıfır fark). paidDays return değeri de dim-ab olarak güncellendi (31g ücretli gösterimi).

https://claude.ai/code/session_01KFPRqkMsp5z6fDtnCjDxjg