### PR TITLE
refactor: single source of truth for app version via version.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,12 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
 <title>ShiftTrack Pro</title>
+<script src="version.js"></script>
 <script>
 // Cache buster — eski service worker'ı temizle
+// Sürüm numarası version.js'deki APP_VERSION'dan okunur — o dosyayı güncelle yeter.
 (function(){
-  var CV = 'shifttrack-v20'; // sw.js CACHE_NAME ile eşleştirildi
+  var CV = (typeof APP_VERSION !== 'undefined') ? APP_VERSION : 'shifttrack-v20';
   if (localStorage.getItem('st_cache_ver') !== CV) {
     localStorage.setItem('st_cache_ver', CV);
     if ('serviceWorker' in navigator) {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,7 @@
-const CACHE_NAME = 'shifttrack-v20';
-const CORE_ASSETS = ['./', './index.html', './manifest.json', './assets/icons/icon-192.png', './assets/icons/icon-512.png'];
+importScripts('./version.js'); // APP_VERSION burada tanımlanır
+
+const CACHE_NAME = APP_VERSION;
+const CORE_ASSETS = ['./', './index.html', './version.js', './manifest.json', './assets/icons/icon-192.png', './assets/icons/icon-512.png'];
 const CDN_ASSETS = [
   'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800;900&display=swap',
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css'

--- a/version.js
+++ b/version.js
@@ -1,0 +1,3 @@
+// Uygulama sürüm numarası — yeni güncelleme deploy ederken YALNIZCA bu dosyayı değiştir.
+// Hem service worker cache adı hem de HTML cache buster bu değeri kullanır.
+const APP_VERSION = 'shifttrack-v20';


### PR DESCRIPTION
- Add version.js: const APP_VERSION = 'shifttrack-v20'
- sw.js: importScripts('./version.js'), use APP_VERSION as CACHE_NAME
- sw.js: add version.js to CORE_ASSETS so it's always cached
- index.html: load version.js before cache buster, read APP_VERSION from it

To deploy an update, only ONE file needs changing: version.js

https://claude.ai/code/session_01F438CyYB5jzQQGfJRa1Vg7