### PR TITLE
fix: O7 FM saat tabanı tutarlılığı + O6 gece primi uyarısı + Faz 0 re…

### DIFF
--- a/app.js
+++ b/app.js
@@ -3820,7 +3820,10 @@ function estimatePayrollForMonth(u, y, m, d) {
   const absentDays = Math.max(0, safeNum(earning.absentDays, 0));
   const proRate = Math.max(0, Math.min(1, (30 - absentDays) / 30));
   const baseGross = _bordroRound2(fullGross * proRate);
-  const hrGross = fullGross > 0 ? _bordroRound2(fullGross / getMonthlyHours(u)) : 0;
+  // [FIX O7] FM saat ücreti yasal saat tabanından (payrollHourBasis) — e-Bordro ile tutarlı.
+  // Önceden getMonthlyHours(u) kullanılıyordu; monthlyHours≠225 olan kullanıcılarda bu ekran
+  // ile e-Bordro farklı fazla mesai ücreti gösteriyordu.
+  const hrGross = (fullGross > 0 && payrollHourBasis > 0) ? _bordroRound2(fullGross / payrollHourBasis) : 0;
   const drGross = _bordroRound2(fullGross / 30);
   const compMode = u.otCompMode || 'pay';
   const compRate = getOTRate(u);
@@ -9139,6 +9142,7 @@ function renderBordroPreview() {
     ${ot125Gross > 0 ? `<div class="bordro-row add"><span class="bl">Fazla Çalışma %25 (${ot125Hours.toFixed(1)}s × ${fmr(hrGross)}₺ × ${partialRate})</span><span class="bv">+ ${fmb(ot125Gross)}</span></div>` : ''}
     ${otGross > 0 ? `<div class="bordro-row add"><span class="bl">Fazla Mesai %50 (${otHours.toFixed(1)}s × ${fmr(hrGross)}₺ × ${compRate})</span><span class="bv">+ ${fmb(otGross)}</span></div>` : ''}
     ${nightGross > 0 ? `<div class="bordro-row add"><span class="bl">Gece Çalışma Zammı (${nightHrs.toFixed(1)}s × ${fmr(hrGross)}₺ × ${nightRate})</span><span class="bv">+ ${fmb(nightGross)}</span></div>` : ''}
+    ${(nightHrs > 0 && nightRate <= 0) ? `<div class="bordro-row info"><span class="bl"><i class="fas fa-info-circle" style="color:#fbbf24"></i> Gece Primi</span><span class="bv">${nightHrs.toFixed(1)}s var, oran tanımsız (hesaba katılmadı)</span></div>` : ''}
     ${holGross > 0 ? `<div class="bordro-row add"><span class="bl">Genel Tatil (Çalıştı) — ${fmr(holPayDays)}g × ${fmr(drGross)}₺ ek ücret (Md.47)</span><span class="bv">+ ${fmb(holGross)}</span></div>` : ''}
     ${hasExtras ? `<div class="bordro-row sub"><span class="bl">TOPLAM BRÜT</span><span class="bv">${fmb(totalGross)}</span></div>` : ''}
     <div class="bordro-row deduct"><span class="bl">SGK İşçi Payı (%14)</span><span class="bv">− ${fmb(res.sgkDeduction)}</span></div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "shiftt",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Shiftt — Firebase tabanlı, çevrimdışı çalışabilen (PWA) vardiya & bordro uygulaması",
+  "scripts": {
+    "test": "node --test \"tests/**/*.test.mjs\""
+  }
+}

--- a/tests/loader.mjs
+++ b/tests/loader.mjs
@@ -1,0 +1,73 @@
+// Faz 0 test yükleyici — app.js'i DEĞİŞTİRMEDEN saf fonksiyonları izole eder.
+// app.js tarayıcı için tek-parça global script olduğundan (modül sistemi yok), burada
+// hedef fonksiyonların geçişli (transitive) bağımlılık kapanışını kaynaktan çıkarıp
+// izole bir sandbox'ta değerlendiririz. Böylece firebase/DOM yüklemeden bordro/sayı
+// fonksiyonlarını GERÇEK koddan test edebiliriz.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(__dirname, '..', 'app.js'), 'utf-8');
+const LINES = SRC.split('\n');
+
+const FN_RE = /^function ([a-zA-Z_$][\w$]*)\s*\(/;
+const CONST_RE = /^(?:const|let|var) ([a-zA-Z_$][\w$]*)\s*=/;
+
+// Tüm top-level function ve basit const/var tanımlarını brace eşleyerek indeksle.
+const defs = new Map();
+for (let i = 0; i < LINES.length; ) {
+  const l = LINES[i];
+  let m = FN_RE.exec(l);
+  if (m) {
+    let depth = 0, started = false, j = i;
+    for (; j < LINES.length; j++) {
+      for (const ch of LINES[j]) { if (ch === '{') { depth++; started = true; } else if (ch === '}') depth--; }
+      if (started && depth <= 0) break;
+    }
+    defs.set(m[1], [i, j]); i = j + 1; continue;
+  }
+  m = CONST_RE.exec(l);
+  if (m) {
+    let depth = 0, j = i;
+    for (; j < LINES.length; j++) {
+      for (const ch of LINES[j]) {
+        if ('{[('.includes(ch)) depth++; else if (')]}'.includes(ch)) depth--;
+      }
+      if (depth <= 0 && LINES[j].trimEnd().endsWith(';')) break;
+    }
+    defs.set(m[1], [i, j]); i = j + 1; continue;
+  }
+  i++;
+}
+
+function bodyOf(name) { const [a, b] = defs.get(name); return LINES.slice(a, b + 1).join('\n'); }
+
+function depsOf(name) {
+  const b = bodyOf(name);
+  const ids = new Set();
+  for (const mm of b.matchAll(/\b([a-zA-Z_$][\w$]*)\b/g)) {
+    if (defs.has(mm[1]) && mm[1] !== name) ids.add(mm[1]);
+  }
+  return ids;
+}
+
+// İstenen hedeflerin geçişli bağımlılık kapanışını topla, kaynak sırasını koruyarak
+// izole bir Function sandbox'ında değerlendir ve hedefleri dışa ver.
+export function loadFns(targets) {
+  const seen = new Set();
+  const stack = [...targets];
+  while (stack.length) {
+    const n = stack.pop();
+    if (seen.has(n) || !defs.has(n)) continue;
+    seen.add(n);
+    for (const d of depsOf(n)) if (!seen.has(d)) stack.push(d);
+  }
+  const ordered = [...seen].filter(n => defs.has(n)).sort((a, b) => defs.get(a)[0] - defs.get(b)[0]);
+  const code = ordered.map(bodyOf).join('\n');
+  const ret = '\nreturn {' + targets.filter(t => defs.has(t)).join(',') + '};';
+  // eslint-disable-next-line no-new-func
+  return Function('"use strict";' + code + ret)();
+}
+
+export const hasDef = (name) => defs.has(name);

--- a/tests/payroll.test.mjs
+++ b/tests/payroll.test.mjs
@@ -1,0 +1,111 @@
+// Faz 0 regresyon testleri — app.js'teki saf sayı/bordro fonksiyonlarını kilitler.
+// Amaç: O7 hizalaması ve gelecekteki refactor/modülarizasyonda maaş matematiğinin
+// bozulmadığını kanıtlamak. Değerler MEVCUT (doğru kabul edilen) davranışı yansıtır.
+// Çalıştır: npm test   (veya: node --test tests/)
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { loadFns } from './loader.mjs';
+
+const f = loadFns([
+  'safeNum', 'safeInt', 'safeTimestamp', 'isAmbiguousNumStr',
+  '_bordroRound2', '_bordroCalcGV', 'computeNetFromGross', 'findGrossFromNet',
+]);
+
+const near = (a, b, eps = 0.02) => Math.abs(a - b) <= eps;
+
+test('safeNum — TR sayı formatı parse', () => {
+  assert.equal(f.safeNum('1.500,75'), 1500.75);   // PAYROLL_QA_REPORT regresyonu
+  assert.equal(f.safeNum('1,5'), 1.5);
+  assert.equal(f.safeNum('7.75'), 7.75);
+  assert.equal(f.safeNum('1.234.567,89'), 1234567.89);
+  assert.equal(f.safeNum(2500), 2500);
+  assert.equal(f.safeNum('₺1.500,75'), 1500.75);
+  assert.equal(f.safeNum('abc', 0), 0);
+  assert.equal(f.safeNum('', 42), 42);
+  assert.equal(f.safeNum(null, 7), 7);
+  assert.equal(f.safeNum(Infinity, 9), 9);          // sonsuz → fallback
+});
+
+test('safeInt — tam sayıya indirger', () => {
+  assert.equal(f.safeInt('7.75'), 7);
+  assert.equal(f.safeInt('1.500,99'), 1500);
+  assert.equal(f.safeInt('x', 3), 3);
+});
+
+test('safeTimestamp — Firestore/Date/ISO/number/null', () => {
+  assert.equal(f.safeTimestamp({ seconds: 1710000000, nanoseconds: 500000000 }), 1710000000500);
+  assert.equal(f.safeTimestamp(1710000000500), 1710000000500);
+  assert.equal(f.safeTimestamp(new Date(0)), 0);
+  assert.equal(f.safeTimestamp(null, 0), 0);
+  assert.equal(f.safeTimestamp(undefined, 0), 0);
+  assert.equal(f.safeTimestamp({ toMillis: () => 123 }), 123);
+});
+
+test('isAmbiguousNumStr — belirsiz tek-nokta tespiti (K1 uyarısı)', () => {
+  for (const v of ['1.500', '2.999', '10.500', '1.234']) assert.equal(f.isAmbiguousNumStr(v), true, v);
+  for (const v of ['10.50', '1.500,75', '1.234.567', '1500', '1500,75', '7.75', '']) assert.equal(f.isAmbiguousNumStr(v), false, v);
+});
+
+test('_bordroRound2 — 2 ondalık, float güvenli', () => {
+  assert.equal(f._bordroRound2(0.1 + 0.2), 0.3);
+  assert.equal(f._bordroRound2(1500.005), 1500.01);
+  assert.equal(f._bordroRound2(2.675), 2.68);
+  assert.equal(f._bordroRound2('abc'), 0);
+});
+
+// === Gelir vergisi dilimi (kümülatif) — deterministik, golden ===
+test('_bordroCalcGV — golden dilim hesabı (2025)', () => {
+  assert.equal(f._bordroCalcGV(30000, 2025), 4500);     // ilk dilim %15
+  assert.equal(f._bordroCalcGV(200000, 2025), 32100);
+  assert.equal(f._bordroCalcGV(1000000, 2025), 239000);
+  assert.equal(f._bordroCalcGV(0, 2025), 0);
+  assert.equal(f._bordroCalcGV(-5, 2025), 0);            // negatif → 0
+});
+
+test('_bordroCalcGV — kümülatifte monotonik artış', () => {
+  let prev = -1;
+  for (const ytd of [0, 30000, 100000, 200000, 500000, 1000000]) {
+    const gv = f._bordroCalcGV(ytd, 2025);
+    assert.ok(Number.isFinite(gv) && gv >= 0, 'sonlu/negatif değil');
+    assert.ok(gv >= prev, 'monotonik');
+    prev = gv;
+  }
+});
+
+// === computeNetFromGross — golden ===
+test('computeNetFromGross — golden net (single, ay 0, prior 0, 2025)', () => {
+  const r = f.computeNetFromGross(30000, 'single', 0, 0, 0, undefined, 2025);
+  assert.equal(r.net, 24960.38);
+  assert.equal(r.gvMatrah, 25500);
+  assert.equal(r.sgkDeduction, 4200);
+  const r2 = f.computeNetFromGross(50000, 'single', 0, 0, 0, undefined, 2025);
+  assert.equal(r2.net, 39258.58);
+});
+
+test('computeNetFromGross — net < gross ve sonlu', () => {
+  for (const g of [20000, 30000, 50000, 100000]) {
+    const r = f.computeNetFromGross(g, 'single', 0, 0, 0, undefined, 2025);
+    assert.ok(Number.isFinite(r.net), 'sonlu');
+    assert.ok(r.net > 0 && r.net < g, 'net brütten küçük ve pozitif');
+  }
+});
+
+// === findGrossFromNet — bisection; tolerans + invaryant ===
+test('findGrossFromNet — net→brüt→net yuvarlak tur (±0.02)', () => {
+  for (const net of [20000, 30000, 50000]) {
+    const g = f.findGrossFromNet(net, 'single', 0, 0, 0, undefined, 2025);
+    assert.ok(g > net, 'brüt > net');
+    const back = f.computeNetFromGross(g, 'single', 0, 0, 0, undefined, 2025).net;
+    assert.ok(near(back, net), `geri dönüş ${back} ≈ ${net}`);
+  }
+});
+
+test('findGrossFromNet — monotonik ve golden (±0.02)', () => {
+  assert.ok(near(f.findGrossFromNet(30000, 'single', 0, 0, 0, undefined, 2025), 37049.29));
+  let prev = 0;
+  for (const net of [10000, 20000, 30000, 50000, 80000]) {
+    const g = f.findGrossFromNet(net, 'single', 0, 0, 0, undefined, 2025);
+    assert.ok(g > prev, 'monotonik artış');
+    prev = g;
+  }
+});


### PR DESCRIPTION
…gresyon testleri

Gizli çakışma/state analizinin kalan kalemleri (kullanıcı kararıyla):

O7 — FM saat ücreti tabanı hizalandı:
- estimatePayrollForMonth (dashboard/projeksiyon) hrGross'u zaten aynı fonksiyonda hesaplanan payrollHourBasis (yasal taban) yerine getMonthlyHours(u) ile bölüyordu. monthlyHours≠225 olan kullanıcılarda bu ekran ile e-Bordro farklı fazla mesai ücreti gösteriyordu. Artık ikisi de payrollHourBasis kullanıyor. Çekirdek matematik (computeNetFromGross/findGrossFromNet/_bordroCalcGV) DOKUNULMADI.

O6 — Gece primi farkındalık uyarısı:
- Varsayılan oran 0 KORUNDU (yasal olarak doğru, maaş DEĞİŞMEZ).
- e-Bordro önizlemesine additif satır: gece saati var ama nightShiftRate tanımsız/0 ise "oran tanımsız, hesaba katılmadı" bilgisi gösterilir.

Faz 0 — Regresyon test altyapısı (npm test):
- tests/loader.mjs: app.js'i DEĞİŞTİRMEDEN, hedef saf fonksiyonların geçişli bağımlılık kapanışını kaynaktan çıkarıp izole Function sandbox'ında değerlendirir (firebase/DOM yüklemeden gerçek kodu test eder). Modülarizasyon öncesi emniyet ağı.
- tests/payroll.test.mjs: node:test ile 11 golden/regresyon testi — safeNum, safeInt, safeTimestamp, isAmbiguousNumStr, _bordroRound2, _bordroCalcGV, computeNetFromGross, findGrossFromNet davranışını kilitler (deterministik golden + net→brüt→net yuvarlak tur ±0.02). Harici bağımlılık yok (Node yerleşik test runner). 11/11 yeşil.

Y5 (priorYTD zinciri) incelendi: gerçek kodda zaten tam zincir mevcut — ek düzeltme gerekmedi.

https://claude.ai/code/session_011NPcBN3BJ18b2ufsTc1wnQ