### PR TITLE
Güvenlik, senkron veri bütünlüğü, bordro tutarlılığı ve erişilebilirlik düzeltmeleri

### DIFF
--- a/app.js
+++ b/app.js
@@ -345,7 +345,9 @@ function toast(msg, type = 'info') {
   const ic = { success:'fa-check-circle', error:'fa-times-circle', info:'fa-info-circle', warning:'fa-exclamation-triangle' };
   const t = document.createElement('div');
   t.className = `toast t-${type}`;
-  t.innerHTML = `<i class="fas ${ic[type] || ic.info}"></i><span>${escHtml(msg)}</span>`;
+  // [A11Y] Dekoratif ikonu ekran okuyuculardan gizle; hata/uyarıyı anında duyur.
+  t.setAttribute('role', (type === 'error' || type === 'warning') ? 'alert' : 'status');
+  t.innerHTML = `<i class="fas ${ic[type] || ic.info}" aria-hidden="true"></i><span>${escHtml(msg)}</span>`;
   c.appendChild(t);
   setTimeout(() => {
     t.classList.add('toast-out');
@@ -1831,6 +1833,105 @@ function chgYear(d) {
 /* ============================================================
    INIT
 ============================================================ */
+/* ============================================================
+   [A11Y] Erişilebilirlik katmanı — merkezi, iş mantığına dokunmaz.
+   Modal dialog semantiği + focus trap + focus geri dönüşü,
+   ikon-yalnız düğmelere otomatik ad, dekoratif ikon gizleme,
+   tıklanabilir div/span'a klavye erişimi.
+============================================================ */
+// .show class'ı ile açılan modal/overlay kapsayıcıları ve başlık eşlemesi.
+const A11Y_MODALS = {
+  modal: 'mTitle', wtModal: 'wtModalTitle', cpModal: null, newUserModal: null,
+  confirmOverlay: 'confirmTitle', pinOverlay: 'pinTitle', qrOverlay: null,
+  docUploadModal: null, docViewer: null, calcOverlay: null, employerOverlay: null,
+  eBordroModal: null,
+};
+let _a11yLastFocus = null;
+
+function _a11yFocusable(container) {
+  return Array.from(container.querySelectorAll(
+    'a[href],button:not([disabled]),input:not([disabled]):not([type=hidden]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])'
+  )).filter(el => el.offsetParent !== null || el === document.activeElement);
+}
+
+function _a11yTrap(e, container) {
+  if (e.key !== 'Tab') return;
+  const f = _a11yFocusable(container);
+  if (!f.length) return;
+  const first = f[0], last = f[f.length - 1];
+  if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+  else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+}
+
+function _a11yOnModalOpen(el, titleId) {
+  el.setAttribute('role', 'dialog');
+  el.setAttribute('aria-modal', 'true');
+  if (titleId && document.getElementById(titleId)) el.setAttribute('aria-labelledby', titleId);
+  _a11yLastFocus = document.activeElement;
+  // İçerikteki ilk odaklanabilir öğeye odak ver.
+  const f = _a11yFocusable(el);
+  setTimeout(() => { (f[0] || el).focus({ preventScroll: true }); }, 30);
+  if (!el._a11yTrapBound) {
+    el._a11yTrapBound = (e) => _a11yTrap(e, el);
+    el.addEventListener('keydown', el._a11yTrapBound);
+  }
+}
+
+function _a11yOnModalClose(el) {
+  // Tetikleyen öğeye odağı geri ver.
+  if (_a11yLastFocus && typeof _a11yLastFocus.focus === 'function') {
+    try { _a11yLastFocus.focus({ preventScroll: true }); } catch (_) {}
+  }
+  _a11yLastFocus = null;
+}
+
+// Tek seferlik: modal açılış/kapanışını .show class değişiminden izle.
+function setupA11yModals() {
+  Object.keys(A11Y_MODALS).forEach(id => {
+    const el = document.getElementById(id);
+    if (!el || el._a11yObserved) return;
+    el._a11yObserved = true;
+    // dialog kapsayıcının kendisi odaklanabilir olsun (içerik boşsa fallback).
+    if (!el.hasAttribute('tabindex')) el.setAttribute('tabindex', '-1');
+    let wasShown = el.classList.contains('show');
+    const obs = new MutationObserver(() => {
+      const shown = el.classList.contains('show');
+      if (shown === wasShown) return;
+      wasShown = shown;
+      if (shown) _a11yOnModalOpen(el, A11Y_MODALS[id]); else _a11yOnModalClose(el);
+    });
+    obs.observe(el, { attributes: true, attributeFilter: ['class'] });
+  });
+}
+
+// İkon-yalnız düğmelere otomatik erişilebilir ad; dekoratif ikonları gizle.
+// title varsa onu aria-label'a kopyalar; klavyeyle erişilebilir div/span'a rol/tabindex verir.
+function enhanceA11y(root) {
+  root = root || document;
+  // 1) Dekoratif Font Awesome ikonlarını ekran okuyuculardan gizle.
+  root.querySelectorAll('i.fas:not([aria-hidden]),i.far:not([aria-hidden]),i.fab:not([aria-hidden])')
+    .forEach(ic => ic.setAttribute('aria-hidden', 'true'));
+  // 2) Metinsiz (ikon-yalnız) butonlara ad ver.
+  root.querySelectorAll('button:not([aria-label])').forEach(btn => {
+    const txt = (btn.textContent || '').trim();
+    if (txt) return; // metni olan butona dokunma
+    const t = btn.getAttribute('title');
+    if (t) { btn.setAttribute('aria-label', t); }
+  });
+  // 3) Tıklanabilir div/span'lara klavye erişimi (role=button + tabindex + Enter/Space).
+  root.querySelectorAll('[onclick]').forEach(el => {
+    const tag = el.tagName;
+    if (tag === 'BUTTON' || tag === 'A' || tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA' || tag === 'LABEL') return;
+    if (el._a11yKbd) return;
+    el._a11yKbd = true;
+    if (!el.hasAttribute('role')) el.setAttribute('role', 'button');
+    if (!el.hasAttribute('tabindex')) el.setAttribute('tabindex', '0');
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); el.click(); }
+    });
+  });
+}
+
 function init() {
   loadLS();
   applyTheme('default');
@@ -1880,6 +1981,14 @@ function init() {
   const cpModalEl = $('cpModal'); if (cpModalEl) cpModalEl.addEventListener('click', function(e) { if (e.target === this) closeCPModal(); });
   const nuModalEl = $('newUserModal'); if (nuModalEl) nuModalEl.addEventListener('click', function(e) { if (e.target === this) closeNewUserModal(); });
   const nuInput = $('newUserName'); if (nuInput) nuInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') confirmNewUser(); });
+
+  // [A11Y] Modal dialog semantiği/focus yönetimi + statik içeriğe erişilebilirlik geçişi.
+  setupA11yModals();
+  enhanceA11y(document);
+  // Dinamik render sonrası yeni eklenen ikon-buton/div'leri de iyileştir (hafif throttle).
+  let _a11yT;
+  new MutationObserver(() => { clearTimeout(_a11yT); _a11yT = setTimeout(() => enhanceA11y(document), 300); })
+    .observe(document.body, { childList: true, subtree: true });
 }
 
 function setupKeyboardShortcuts() {

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 </head>
 <body>
 
-<div class="toast-container" id="toastContainer"></div>
+<div class="toast-container" id="toastContainer" role="status" aria-live="polite" aria-atomic="false"></div>
 
 <!-- CONFIRM -->
 <div class="confirm-overlay" id="confirmOverlay">
@@ -68,7 +68,7 @@
       <button class="modal-x" onclick="closeNewUserModal()" aria-label="Kapat"><i class="fas fa-times"></i></button>
     </div>
     <div class="modal-body">
-      <div class="fg"><label>Kullanıcı Adı</label><input type="text" id="newUserName" placeholder="İsim girin..." maxlength="30" autocomplete="off"></div>
+      <div class="fg"><label for="newUserName">Kullanıcı Adı</label><input type="text" id="newUserName" placeholder="İsim girin..." maxlength="30" autocomplete="off"></div>
     </div>
     <div class="modal-foot">
       <button class="btn btn-ghost btn-sm" onclick="closeNewUserModal()">İptal</button>
@@ -90,9 +90,9 @@
         <button class="btn btn-danger btn-sm" onclick="wtSetOff()"><i class="fas fa-times"></i>İzin</button>
       </div>
       <div class="time-inputs">
-        <div class="ti"><label>Giriş</label><input type="time" id="wtStart" value="08:00"></div>
-        <div class="ti"><label>Çıkış</label><input type="time" id="wtEnd" value="16:00"></div>
-        <div class="ti"><label>Mola</label>
+        <div class="ti"><label for="wtStart">Giriş</label><input type="time" id="wtStart" value="08:00"></div>
+        <div class="ti"><label for="wtEnd">Çıkış</label><input type="time" id="wtEnd" value="16:00"></div>
+        <div class="ti"><label for="wtBreak">Mola</label>
           <select id="wtBreak">
             <option value="0">Yok</option><option value="15">15dk</option>
             <option value="30" selected>30dk</option><option value="45">45dk</option><option value="60">1s</option>
@@ -113,15 +113,15 @@
   <div class="cp-modal">
     <div class="cp-modal-top"><h3>Yeni Vardiya Şablonu</h3><button class="modal-x" onclick="closeCPModal()" aria-label="Kapat"><i class="fas fa-times"></i></button></div>
     <div class="cp-modal-body">
-      <div class="fg"><label>Şablon Adı</label><input type="text" id="cpName" placeholder="Gece vardiyası..." maxlength="30"></div>
+      <div class="fg"><label for="cpName">Şablon Adı</label><input type="text" id="cpName" placeholder="Gece vardiyası..." maxlength="30"></div>
       <div class="fg">
         <label>İkon</label>
         <div class="emoji-grid" id="emojiGrid"></div>
       </div>
       <div class="time-inputs">
-        <div class="ti"><label>Giriş</label><input type="time" id="cpStart" value="22:00"></div>
-        <div class="ti"><label>Çıkış</label><input type="time" id="cpEnd" value="06:00"></div>
-        <div class="ti"><label>Mola</label>
+        <div class="ti"><label for="cpStart">Giriş</label><input type="time" id="cpStart" value="22:00"></div>
+        <div class="ti"><label for="cpEnd">Çıkış</label><input type="time" id="cpEnd" value="06:00"></div>
+        <div class="ti"><label for="cpBreak">Mola</label>
           <select id="cpBreak">
             <option value="0">Yok</option><option value="15">15dk</option>
             <option value="30" selected>30dk</option><option value="45">45dk</option><option value="60">1s</option>
@@ -147,8 +147,8 @@
       <button class="pin-key" onclick="pinInput(1)">1</button><button class="pin-key" onclick="pinInput(2)">2</button><button class="pin-key" onclick="pinInput(3)">3</button>
       <button class="pin-key" onclick="pinInput(4)">4</button><button class="pin-key" onclick="pinInput(5)">5</button><button class="pin-key" onclick="pinInput(6)">6</button>
       <button class="pin-key" onclick="pinInput(7)">7</button><button class="pin-key" onclick="pinInput(8)">8</button><button class="pin-key" onclick="pinInput(9)">9</button>
-      <button class="pin-key pk-action" onclick="pinClear()"><i class="fas fa-backspace"></i></button><button class="pin-key" onclick="pinInput(0)">0</button>
-      <button class="pin-key pk-action" onclick="pinCancel()"><i class="fas fa-times"></i></button>
+      <button class="pin-key pk-action" onclick="pinClear()" aria-label="Sil"><i class="fas fa-backspace" aria-hidden="true"></i></button><button class="pin-key" onclick="pinInput(0)">0</button>
+      <button class="pin-key pk-action" onclick="pinCancel()" aria-label="İptal"><i class="fas fa-times" aria-hidden="true"></i></button>
     </div>
   </div>
 </div>
@@ -192,11 +192,11 @@
     </div>
     <div class="upload-progress" id="uploadProgress"><div class="upload-progress-bar" id="uploadProgressBar"></div></div>
     <div class="fg" style="margin-bottom:10px">
-      <label class="fl">Belge Adı</label>
+      <label class="fl" for="docNameInput">Belge Adı</label>
       <input type="text" id="docNameInput" placeholder="örn. Hijyen Sertifikası 2025" maxlength="60">
     </div>
     <div class="fg" style="margin-bottom:14px">
-      <label class="fl">Kategori</label>
+      <label class="fl" for="docCatSelect">Kategori</label>
       <select id="docCatSelect">
         <option value="hygiene">🧼 Hijyen Belgesi</option>
         <option value="mastery">🏆 Ustalık Belgesi</option>
@@ -224,7 +224,7 @@
   <div class="dv-bar" onclick="event.stopPropagation()">
     <span class="dv-name" id="dvName"></span>
     <button class="btn btn-soft btn-xs" id="dvWaBtn" onclick="shareDocWA(currentViewDoc)"><i class="fab fa-whatsapp"></i>WhatsApp</button>
-    <button class="btn btn-outline btn-xs" onclick="closeDocViewer()"><i class="fas fa-times"></i></button>
+    <button class="btn btn-outline btn-xs" onclick="closeDocViewer()" aria-label="Kapat"><i class="fas fa-times" aria-hidden="true"></i></button>
   </div>
   <div id="dvContent" onclick="event.stopPropagation()"></div>
 </div>
@@ -237,12 +237,12 @@
       <button class="modal-x" onclick="closeCalc()" aria-label="Kapat"><i class="fas fa-times"></i></button>
     </div>
     <p style="font-size:11px;color:var(--t2);margin-bottom:14px">"X tarihten Y tarihine kadar çalışırsam ne kadar kazanırım?" simülasyonu</p>
-    <div class="fg"><label>Başlangıç Tarihi</label><input type="date" id="calcDateFrom"></div>
-    <div class="fg"><label>Bitiş Tarihi</label><input type="date" id="calcDateTo"></div>
+    <div class="fg"><label for="calcDateFrom">Başlangıç Tarihi</label><input type="date" id="calcDateFrom"></div>
+    <div class="fg"><label for="calcDateTo">Bitiş Tarihi</label><input type="date" id="calcDateTo"></div>
     <div class="time-inputs" style="margin-top:8px">
-      <div class="ti"><label>Giriş</label><input type="time" id="calcStart" value="08:00"></div>
-      <div class="ti"><label>Çıkış</label><input type="time" id="calcEnd" value="16:00"></div>
-      <div class="ti"><label>Mola</label>
+      <div class="ti"><label for="calcStart">Giriş</label><input type="time" id="calcStart" value="08:00"></div>
+      <div class="ti"><label for="calcEnd">Çıkış</label><input type="time" id="calcEnd" value="16:00"></div>
+      <div class="ti"><label for="calcBreak">Mola</label>
         <select id="calcBreak">
           <option value="0">Yok</option><option value="15">15dk</option>
           <option value="30" selected>30dk</option><option value="45">45dk</option><option value="60">1s</option>
@@ -271,9 +271,9 @@
     </div>
     <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;flex-wrap:wrap">
       <div class="cal-nav">
-        <button class="cal-nav-btn" onclick="chgTeamWeek(-1)"><i class="fas fa-chevron-left"></i></button>
+        <button class="cal-nav-btn" onclick="chgTeamWeek(-1)" aria-label="Önceki hafta"><i class="fas fa-chevron-left" aria-hidden="true"></i></button>
         <span class="cal-month-title" id="teamWeekTitle" style="font-size:14px;min-width:200px"></span>
-        <button class="cal-nav-btn" onclick="chgTeamWeek(1)"><i class="fas fa-chevron-right"></i></button>
+        <button class="cal-nav-btn" onclick="chgTeamWeek(1)" aria-label="Sonraki hafta"><i class="fas fa-chevron-right" aria-hidden="true"></i></button>
       </div>
       <button class="btn btn-soft btn-sm" onclick="teamGoThisWeek()"><i class="fas fa-crosshairs"></i>Bu Hafta</button>
     </div>
@@ -339,14 +339,14 @@
       <button class="auth-tab" onclick="authTab('register',this)">Kayıt Ol</button>
     </div>
     <div id="authLoginPane">
-      <div class="auth-fg"><label>E-posta</label><input type="email" id="authEmail" placeholder="ornek@mail.com" autocomplete="email"></div>
-      <div class="auth-fg"><label>Şifre</label><input type="password" id="authPass" placeholder="••••••" autocomplete="current-password"></div>
+      <div class="auth-fg"><label for="authEmail">E-posta</label><input type="email" id="authEmail" placeholder="ornek@mail.com" autocomplete="email"></div>
+      <div class="auth-fg"><label for="authPass">Şifre</label><input type="password" id="authPass" placeholder="••••••" autocomplete="current-password"></div>
       <button class="auth-btn" id="authLoginBtn" onclick="firebaseLogin()"><i class="fas fa-sign-in-alt" style="margin-right:6px"></i>Giriş Yap</button>
     </div>
     <div id="authRegisterPane" style="display:none">
-      <div class="auth-fg"><label>E-posta</label><input type="email" id="authRegEmail" placeholder="ornek@mail.com" autocomplete="email"></div>
-      <div class="auth-fg"><label>Şifre (min 6 karakter)</label><input type="password" id="authRegPass" placeholder="••••••" autocomplete="new-password"></div>
-      <div class="auth-fg"><label>Şifre Tekrar</label><input type="password" id="authRegPass2" placeholder="••••••" autocomplete="new-password"></div>
+      <div class="auth-fg"><label for="authRegEmail">E-posta</label><input type="email" id="authRegEmail" placeholder="ornek@mail.com" autocomplete="email"></div>
+      <div class="auth-fg"><label for="authRegPass">Şifre (min 6 karakter)</label><input type="password" id="authRegPass" placeholder="••••••" autocomplete="new-password"></div>
+      <div class="auth-fg"><label for="authRegPass2">Şifre Tekrar</label><input type="password" id="authRegPass2" placeholder="••••••" autocomplete="new-password"></div>
       <button class="auth-btn" id="authRegBtn" onclick="firebaseRegister()"><i class="fas fa-user-plus" style="margin-right:6px"></i>Kayıt Ol</button>
     </div>
     <div class="auth-divider">veya</div>
@@ -466,9 +466,9 @@
       <div class="card">
         <div class="cal-controls">
           <div class="cal-nav">
-            <button class="cal-nav-btn" onclick="chgM(-1)"><i class="fas fa-chevron-left"></i></button>
+            <button class="cal-nav-btn" onclick="chgM(-1)" aria-label="Önceki ay"><i class="fas fa-chevron-left" aria-hidden="true"></i></button>
             <span class="cal-month-title" id="calTitle"></span>
-            <button class="cal-nav-btn" onclick="chgM(1)"><i class="fas fa-chevron-right"></i></button>
+            <button class="cal-nav-btn" onclick="chgM(1)" aria-label="Sonraki ay"><i class="fas fa-chevron-right" aria-hidden="true"></i></button>
           </div>
           <span style="font-size:11px;color:var(--t3);font-weight:600" id="calSummary"></span>
         </div>
@@ -502,8 +502,8 @@
           <h3><i class="fas fa-history"></i>Geçmiş — <span id="leaveYr"></span></h3>
           <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
             <div class="leave-year-nav">
-              <button onclick="chgLeaveYear(-1)"><i class="fas fa-chevron-left"></i></button>
-              <button onclick="chgLeaveYear(1)"><i class="fas fa-chevron-right"></i></button>
+              <button onclick="chgLeaveYear(-1)" aria-label="Önceki yıl"><i class="fas fa-chevron-left" aria-hidden="true"></i></button>
+              <button onclick="chgLeaveYear(1)" aria-label="Sonraki yıl"><i class="fas fa-chevron-right" aria-hidden="true"></i></button>
             </div>
             <select id="leaveFilter" onchange="renderLeaves()" style="padding:4px 8px;font-size:11px;width:auto">
               <option value="all">Tümü</option>
@@ -524,9 +524,9 @@
       <div class="page-head"><div><h1>Kazanç Raporu</h1><p>Aylık gelir detayları</p></div></div>
       <div class="cal-controls" style="margin-bottom:16px">
         <div class="cal-nav">
-          <button class="cal-nav-btn" onclick="chgE(-1)"><i class="fas fa-chevron-left"></i></button>
+          <button class="cal-nav-btn" onclick="chgE(-1)" aria-label="Önceki ay"><i class="fas fa-chevron-left" aria-hidden="true"></i></button>
           <span class="cal-month-title" id="earnTitle"></span>
-          <button class="cal-nav-btn" onclick="chgE(1)"><i class="fas fa-chevron-right"></i></button>
+          <button class="cal-nav-btn" onclick="chgE(1)" aria-label="Sonraki ay"><i class="fas fa-chevron-right" aria-hidden="true"></i></button>
         </div>
       </div>
       <div id="earnContent"></div>
@@ -572,16 +572,16 @@
 
       <div class="card s-card">
         <h3><i class="fas fa-user"></i>Kişisel Bilgiler</h3>
-        <div class="fg"><label>Ad Soyad</label><input type="text" id="sName" placeholder="Adınız" onchange="sSet('name',this.value)"></div>
-        <div class="fg"><label>İşe Başlama</label><input type="date" id="sStart" onchange="sSet('startDate',this.value)"></div>
-        <div class="fg"><label>Doğum Tarihi</label><input type="date" id="sBirth" onchange="sSet('birthDate',this.value)"></div>
+        <div class="fg"><label for="sName">Ad Soyad</label><input type="text" id="sName" placeholder="Adınız" onchange="sSet('name',this.value)"></div>
+        <div class="fg"><label for="sStart">İşe Başlama</label><input type="date" id="sStart" onchange="sSet('startDate',this.value)"></div>
+        <div class="fg"><label for="sBirth">Doğum Tarihi</label><input type="date" id="sBirth" onchange="sSet('birthDate',this.value)"></div>
         <div id="seniorityInfo"></div>
       </div>
 
       <div class="card s-card">
         <h3><i class="fas fa-money-bill-wave"></i>Maaş</h3>
         <div class="hint"><i class="fas fa-lightbulb"></i><span>Net maaş girin. Günlük = maaş ÷ 30. Tam ay çalışınca tam maaş alınır.</span></div>
-        <div class="fg"><label>Aylık Net (₺)</label><input type="number" id="sSalary" placeholder="25000" min="0" step="100" onchange="sSet('netSalary',this.value)"></div>
+        <div class="fg"><label for="sSalary">Aylık Net (₺)</label><input type="number" id="sSalary" placeholder="25000" min="0" step="100" onchange="sSet('netSalary',this.value)"></div>
         <div class="salary-preview" id="salPrev" style="display:none">
           <div class="amt" id="salAmt">₺0</div>
           <div class="det" id="salDet"></div>
@@ -598,7 +598,7 @@
           <button class="rst-tab" type="button" onclick="rsSwitch('gross')">Hedef Brüt</button>
         </div>
         <div class="fg" id="rsInputWrap">
-          <label id="rsLabel">Zam Oranı (%)</label>
+          <label id="rsLabel" for="rsInput">Zam Oranı (%)</label>
           <input type="number" id="rsInput" placeholder="25" min="0" step="0.5" oninput="renderRaiseSim()">
         </div>
         <div id="rsResult" class="raise-sim-result"></div>
@@ -606,14 +606,14 @@
 
       <div class="card s-card">
         <h3><i class="fas fa-calendar-check"></i>Yıllık İzin</h3>
-        <div class="fg"><label>İzin Hakkı (gün)</label><input type="number" id="sLeave" placeholder="14" min="0" max="40" onchange="sSet('annualLeave',this.value)"></div>
+        <div class="fg"><label for="sLeave">İzin Hakkı (gün)</label><input type="number" id="sLeave" placeholder="14" min="0" max="40" onchange="sSet('annualLeave',this.value)"></div>
       </div>
 
       <div class="card s-card">
         <h3><i class="fas fa-bullseye"></i>Aylık Saat Hedefi</h3>
         <div class="hint"><i class="fas fa-lightbulb"></i><span>Saatlik ücret hesaplaması için aylık toplam çalışma saati. Varsayılan: 225 (Yargıtay 9.HD: 30 gün × 7,5s). Tercihe göre 195 (45×52,18÷12) da kullanılabilir.</span></div>
-        <div class="fg"><label>Aylık Saat</label><input type="number" id="sMH" placeholder="225" min="100" max="400" step="5" onchange="sSet('monthlyHours',this.value)"></div>
-        <div class="fg" style="margin-top:8px"><label>Haftalık Sözleşme Saati</label><input type="number" id="sWCH" placeholder="45" min="15" max="45" step="1" onchange="sSet('weeklyContractHours',this.value)">
+        <div class="fg"><label for="sMH">Aylık Saat</label><input type="number" id="sMH" placeholder="225" min="100" max="400" step="5" onchange="sSet('monthlyHours',this.value)"></div>
+        <div class="fg" style="margin-top:8px"><label for="sWCH">Haftalık Sözleşme Saati</label><input type="number" id="sWCH" placeholder="45" min="15" max="45" step="1" onchange="sSet('weeklyContractHours',this.value)">
           <small style="color:var(--t3);font-size:10px;margin-top:2px;display:block">Sözleşme 45'ten az ise (örn. 40s), aradaki saatler %25 zamlı (fazla sürelerle çalışma) ödenir.</small>
         </div>
       </div>
@@ -629,7 +629,7 @@
             <label class="radio-opt"><input type="radio" name="otMode" data-ot-mode="1" value="leave" onchange="sSet('otCompMode',this.value)"> 🏖️ İzin biriktir</label>
           </div>
         </div>
-        <div class="fg"><label>FM Katsayısı</label><input type="number" id="sOTRate" placeholder="1.5" min="1.5" max="3" step="0.5" onchange="sSet('otCompRate',this.value)"><small style="color:var(--t3);font-size:10px;margin-top:2px;display:block">TR İş Kanunu gereği minimum 1.5×</small></div>
+        <div class="fg"><label for="sOTRate">FM Katsayısı</label><input type="number" id="sOTRate" placeholder="1.5" min="1.5" max="3" step="0.5" onchange="sSet('otCompRate',this.value)"><small style="color:var(--t3);font-size:10px;margin-top:2px;display:block">TR İş Kanunu gereği minimum 1.5×</small></div>
         <div class="fg" style="margin-top:10px">
           <label>FM Hesap Modu</label>
           <div class="radio-row" id="otCalcModeRow">
@@ -657,8 +657,8 @@
       <div class="card s-card">
         <h3><i class="fas fa-bullseye"></i>Hedefler</h3>
         <div class="hint"><i class="fas fa-lightbulb"></i><span>Aylık saat ve kazanç hedefi belirleyin. Dashboard'da ilerleme gösterilir.</span></div>
-        <div class="fg"><label>Aylık Saat Hedefi</label><input type="number" id="sGoalHours" placeholder="180" min="0" max="400" step="5" onchange="sSet('goalHours',this.value)"></div>
-        <div class="fg"><label>Aylık Kazanç Hedefi (₺)</label><input type="number" id="sGoalEarning" placeholder="30000" min="0" step="500" onchange="sSet('goalEarning',this.value)"></div>
+        <div class="fg"><label for="sGoalHours">Aylık Saat Hedefi</label><input type="number" id="sGoalHours" placeholder="180" min="0" max="400" step="5" onchange="sSet('goalHours',this.value)"></div>
+        <div class="fg"><label for="sGoalEarning">Aylık Kazanç Hedefi (₺)</label><input type="number" id="sGoalEarning" placeholder="30000" min="0" step="500" onchange="sSet('goalEarning',this.value)"></div>
       </div>
 
       <div class="card s-card">
@@ -782,9 +782,9 @@
       <div id="mShift">
         <div class="preset-row" id="presetRow"></div>
         <div class="time-inputs">
-          <div class="ti"><label>Giriş</label><input type="time" id="iStart" value="08:00"></div>
-          <div class="ti"><label>Çıkış</label><input type="time" id="iEnd" value="16:00"></div>
-          <div class="ti"><label>Mola</label>
+          <div class="ti"><label for="iStart">Giriş</label><input type="time" id="iStart" value="08:00"></div>
+          <div class="ti"><label for="iEnd">Çıkış</label><input type="time" id="iEnd" value="16:00"></div>
+          <div class="ti"><label for="iBreak">Mola</label>
             <select id="iBreak">
               <option value="0">Yok</option><option value="15">15dk</option>
               <option value="30" selected>30dk</option><option value="45">45dk</option>
@@ -818,7 +818,7 @@
     </div>
     <div class="modal-foot">
       <button class="btn btn-outline btn-sm" id="mPaste" onclick="pasteAndClose()" style="display:none;margin-right:auto"><i class="fas fa-paste"></i>Yapıştır</button>
-      <button class="btn btn-outline btn-sm" id="mCopy" onclick="copyShift()" style="display:none"><i class="fas fa-copy"></i></button>
+      <button class="btn btn-outline btn-sm" id="mCopy" onclick="copyShift()" style="display:none" aria-label="Vardiyayı kopyala"><i class="fas fa-copy" aria-hidden="true"></i></button>
       <button class="btn btn-danger btn-sm" id="mDel" onclick="delEntry()" style="display:none"><i class="fas fa-trash"></i>Sil</button>
       <button class="btn btn-ghost btn-sm" onclick="closeM()">İptal</button>
       <button class="btn btn-primary btn-sm" onclick="saveEntry()"><i class="fas fa-check"></i>Kaydet</button>


### PR DESCRIPTION
## Özet

5 uzman-ajan perspektifli derin sistem analizi sonrası tespit edilen **gizli çakışmalar, state hataları, güvenlik açıkları ve erişilebilirlik eksikleri** giderildi. Tüm değişiklikler çekirdek bordro matematiğini koruyacak şekilde uygulandı ve **11/11 regresyon testiyle** doğrulandı.

> Not: Eski `audit-report.md`/`PAYROLL_QA_REPORT.md` denetimlerinden bu yana kod evrildiği için (JS→`app.js`, CSS→`style.css`, `version.js` sürüm senkronu, firestore.rules ara-yol kuralı) bu PR **güncel koddaki kalan/yeni** sorunlara odaklanır.

## Değişiklikler (3 commit)

### 🔒 Güvenlik & senkron veri kaybı (`116758a`)
- **K1 — XSS:** `escHtml` artık tırnakları da kaçırıyor (`"` `'`) → `title="..."` attribute-injection vektörü kapatıldı. Kullanıcı kontrollü ham `title=` interpolasyonları `escHtml()` ile sarıldı.
- **K2 — Sessiz izin kaybı:** `resolveDayConflicts` eşit/0 (legacy) timestamp'te artık izni koruyor (`>` → `>=`); bulut merge'inde sessiz izin silinmesi önlendi.
- **K3 — Buluta gitmeyen değişiklik:** `debouncedPush` senkron sürerken push'u düşürmüyor, yeniden planlıyor.
- **K4 — Çevrimdışı düzenleme ezilmesi:** `deepMergeUser` tie-break'i eşit/0 timestamp'te yerel lehine (`>=` → `>`) — shifts, leaves, notes, payrollChecks, settings.
- **safeNum belirsiz sayı uyarısı:** Sayısal davranış değişmeden, `"1.500"`/`"2.999"` gibi belirsiz girdide blur'da uyarı toast'ı (TR locale korundu).

### ⚙️ Bordro tutarlılığı + test altyapısı (`83eb7cc`)
- **O7:** `estimatePayrollForMonth` FM saat ücretini artık `payrollHourBasis` (yasal taban) üzerinden hesaplıyor → e-Bordro ile tutarlı. `monthlyHours≠225` kullanıcılarında iki ekranın farklı FM ücreti göstermesi giderildi.
- **O6:** Gece primi varsayılanı `0` korundu (yasal olarak doğru); e-Bordro'ya additif uyarı: gece saati var ama oran tanımsızsa bilgi gösterilir.
- **Faz 0 testleri:** `tests/loader.mjs` (app.js'i değiştirmeden saf fonksiyonları izole sandbox'ta yükler) + `tests/payroll.test.mjs` (11 golden/regresyon testi, `node:test`, harici bağımlılık yok). `npm test` ile çalışır.

### ♿ Erişilebilirlik (`2f2a442`)
- **Modal dialog semantiği + focus yönetimi:** 12 modal için `role="dialog"` + `aria-modal` + `aria-labelledby`, focus modala taşıma, focus trap, kapanışta odak geri dönüşü (merkezi `setupA11yModals()`).
- **enhanceA11y():** dekoratif ikonlara `aria-hidden`, ikon-yalnız butonlara `aria-label`, tıklanabilir `div/span`'a `role="button"` + tabindex + Enter/Space (dinamik render için MutationObserver).
- **toast:** `aria-live="polite"`, hata/uyarıda `role="alert"`.
- 12 isimsiz ikon butona `aria-label`; 34 form etiketine `label[for] ↔ input[id]` bağlantısı.

## Doğrulama
- ✅ `node --check app.js` — sözdizimi temiz
- ✅ `npm test` — **11/11 yeşil** (safeNum, safeTimestamp, _bordroCalcGV, computeNetFromGross, findGrossFromNet net→brüt→net yuvarlak tur ±0.02₺)
- ✅ Çekirdek bordro matematiği değiştirilmedi

## Kapsam dışı (bilinçli)
- **Firebase App Check + API anahtarı referrer kısıtlaması (K2/O1):** Firebase Console tarafı yapılandırma + auth akışı; canlı auth'u kırmamak için kod-içi yapılmadı.
- **`prefers-color-scheme`:** Uygulamada manuel tema + `autoThemeToggle` zaten mevcut.
- **Modülarizasyon (Vite/Webpack, Faz 1-4):** Ayrı iş; Faz 0 test ağı artık hazır.

https://claude.ai/code/session_011NPcBN3BJ18b2ufsTc1wnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011NPcBN3BJ18b2ufsTc1wnQ)_