### PR TITLE
chore: sürüm v34 + görünür sürüm etiketini APP_VERSION'a bağla

### DIFF
--- a/app.js
+++ b/app.js
@@ -1982,6 +1982,14 @@ function init() {
   const nuModalEl = $('newUserModal'); if (nuModalEl) nuModalEl.addEventListener('click', function(e) { if (e.target === this) closeNewUserModal(); });
   const nuInput = $('newUserName'); if (nuInput) nuInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') confirmNewUser(); });
 
+  // [SÜRÜM] Görünür sürüm etiketini gerçek APP_VERSION'a bağla — her güncellemede otomatik değişir.
+  try {
+    const _vl = $('appVersionLabel');
+    if (_vl && typeof APP_VERSION !== 'undefined') {
+      _vl.textContent = String(APP_VERSION).replace(/^shifttrack-/, '') + ' Cloud';
+    }
+  } catch (e) {}
+
   // [A11Y] Modal dialog semantiği/focus yönetimi + statik içeriğe erişilebilirlik geçişi.
   setupA11yModals();
   enhanceA11y(document);

--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
       <div class="icon"><i class="fas fa-clock"></i></div>
       <h1>ShiftTrack Pro</h1>
       <p>Akıllı Vardiya &amp; Kazanç Yönetimi</p>
-      <span class="version">v6.7 Cloud</span>
+      <span class="version" id="appVersionLabel">v6.7 Cloud</span>
     </div>
     <div class="login-cards" id="loginCards"></div>
   </div>

--- a/version.js
+++ b/version.js
@@ -1,3 +1,3 @@
 // Uygulama sürüm numarası — yeni güncelleme deploy ederken YALNIZCA bu dosyayı değiştir.
 // Hem service worker cache adı hem de HTML cache buster bu değeri kullanır.
-const APP_VERSION = 'shifttrack-v33';
+const APP_VERSION = 'shifttrack-v34';


### PR DESCRIPTION
- version.js: shifttrack-v33 → v34 (service worker cache buster'ı tetikler; kullanıcılar bu PR'daki güncellemeleri alır).
- Login ekranındaki sabit "v6.7 Cloud" etiketi artık gerçek APP_VERSION'dan doluyor (init'te #appVersionLabel → "v34 Cloud"). Böylece her sürüm güncellemesi kullanıcıya görünür hale gelir.

https://claude.ai/code/session_011NPcBN3BJ18b2ufsTc1wnQ