### PR TITLE
fix(bordro): fazla mesai saatlik bazını marjinal (istisnadan arınmış)…

### DIFF
--- a/app.js
+++ b/app.js
@@ -4007,7 +4007,14 @@ function estimatePayrollForMonth(u, y, m, d) {
     if (baseNet <= 0 && d.th <= 0 && d.mau <= 0 && d.msd <= 0 && d.wr <= 0) return null;
     baseGross = _bordroRound2(findGrossFromNet(baseNet, marital, children, priorYTD, m, undefined, y));
     fullGross = _bordroRound2(findGrossFromNet(W * 30, marital, children, priorYTD, m, undefined, y));
-    hrGross = (fullGross > 0 && payrollHourBasis > 0) ? _bordroRound2(fullGross / payrollHourBasis) : 0;
+    /* [FIX FM-MARJİNAL] FM/hafta sonu saatlik bazı: asgari ücret istisnasından
+       ARINMIŞ marjinal brüt. 4857/41 gereği fazla mesai normal saat ücreti
+       üzerinden hesaplanır; vergi istisnası ücret oranını düşürmez. Bir ek günün
+       marjinal brütü (W×31 − W×30) / günlük standart saat = tatil saatlik brütü. */
+    const _dsh = cfg.dailyStandardHours || 7.5;
+    const marginalDayGross = _bordroRound2(findGrossFromNet(W * 31, marital, children, priorYTD, m, undefined, y) - fullGross);
+    hrGross = marginalDayGross > 0 ? _bordroRound2(marginalDayGross / _dsh)
+            : (fullGross > 0 && payrollHourBasis > 0 ? _bordroRound2(fullGross / payrollHourBasis) : 0);
     drGross = _bordroRound2(fullGross / 30);
     holGross = 0;     // çalışılan tatil ek günü baz içinde
     unpaidGross = 0;  // ödenen güne girmeyen günler zaten hariç
@@ -9263,7 +9270,11 @@ function renderBordroPreview() {
     publicHolidayGross = _bordroRound2(manualPublicHolidayDays * drGross);
     publicHolidayWorkGross = _bordroRound2(manualPublicHolidayWorkDays * drGross);
     normalGross = _bordroRound2(Math.max(0, officialTotalGross - weeklyRestGross - publicHolidayGross - publicHolidayWorkGross));
-    hrGross = manualNormalHours > 0 ? _bordroRound2(normalGross / manualNormalHours) : _bordroRound2((drGross * 30) / payrollHourBasis);
+    /* [FIX FM-MARJİNAL] FM saatlik bazı, asgari ücret istisnasıyla düşmüş normal
+       saatten değil, istisnadan arınmış MARJİNAL (tatil) günlük brütünden alınır:
+       drGross(=tatil günlük brüt) / günlük std saat. 4857/41 ile uyumlu. */
+    hrGross = drGross > 0 ? _bordroRound2(drGross / (cfg.dailyStandardHours || 7.5))
+            : (manualNormalHours > 0 ? _bordroRound2(normalGross / manualNormalHours) : _bordroRound2((drGross * 30) / payrollHourBasis));
     baseGross = _bordroRound2(normalGross + weeklyRestGross + publicHolidayGross);
     otHours = manualOTHours;
     ot125Hours = manualOT125Hours;

--- a/tests/payroll.test.mjs
+++ b/tests/payroll.test.mjs
@@ -125,7 +125,17 @@ test('günlük-net bordro — Ocak 2026 mutabakatı (golden)', () => {
   assert.ok(near(r.stampTax, 170.76, 0.5), 'damga');
 });
 
-// === SGK-muaf ek kazanç (alış-veriş kartı) — Mayıs 2026 (gerçek bordro) ===
+// === FM marjinal saatlik baz — asgari ücret istisnasından arınmış (Mayıs 2026) ===
+// 4857/41: fazla mesai, vergi istisnasıyla düşmüş "ortalama" değil, marjinal saat
+// ücreti üzerinden. Bir ek günün marjinal brütü / 7.5 = tatil saatlik brüt 285,54.
+test('FM marjinal saatlik — istisnadan arınmış (Mayıs 2026, %20 dilim)', () => {
+  const W = 1440, prior = 190000;
+  const marginalDay = f.findGrossFromNet(W * 31, 'single', 0, prior, 4, undefined, 2026)
+                    - f.findGrossFromNet(W * 30, 'single', 0, prior, 4, undefined, 2026);
+  const hourly = marginalDay / 7.5;
+  assert.ok(near(hourly, 285.54, 0.1), `marjinal saatlik ${hourly} ≈ 285,54`);
+  assert.ok(near(19 * hourly * 1.5, 8137.89, 2), 'FM %50 = 19s × 285,54 × 1,5 ≈ 8.137,89');
+});
 // Brüt 86.449,81 (5.710,42 SGK-muaf dahil); SGK matrahı 80.739,39; SGK 11.303,51;
 // GV matrahı 74.338,91; damga 405,45; net (yasal) 63.277.
 test('computeNetFromGross — SGK-muaf ek kazanç: SGK tabanı düşer, GV/damga tam brüt', () => {


### PR DESCRIPTION
… brüte çek

Uygulamanın ürettiği Mayıs bordrosu gerçek bordroyla uyuşmuyordu. Kök neden: FM saatlik ücreti, asgari ücret vergi istisnasıyla düşmüş NORMAL saatten (243,41) hesaplanıyordu; oysa 4857/41 gereği fazla mesai istisnadan arınmış MARJİNAL (tatil) saat ücreti üzerinden (285,54) hesaplanır. Fark FM'de ~1.200 TL.

- estimatePayrollForMonth (günlük-net dalı): hrGross artık marjinal günlük brütten — findGrossFromNet(W×31) − findGrossFromNet(W×30), / günlük std saat.
- e-Bordro officialNetDaily: hrGross = tatil günlük brüt (drGross) / std saat.

Doğrulama (Mayıs 2026, priorYTD %20 dilim + 21 gün + ek kazanç 5.710,43): normal 38.336,68 · hafta 8.566,20 · genel 12.849,30 · tatil-çalıştı 12.849,30 · FM 8.137,89 · SGK matrahı 80.739 · GV 10.656,45 · damga 405,45 · NET 63.277,00 — gerçek bordroyla kuruşu kuruşuna. 14/14 test.