### PR TITLE
feat(bordro): devreden GV matrahını Ocak'tan otomatik zincirle

### DIFF
--- a/app.js
+++ b/app.js
@@ -9103,8 +9103,20 @@ function openEBordroModal(y, m) {
     const prevRec = (prevM === null) ? {} :
       ((u.payrollChecks && u.payrollChecks[employeeMonthKey(prevY, prevM)]) || {});
     const hasManualPrior = rec.priorYTDState === 'manual' || (rec.priorYTDAuto === false && rec.priorYTD !== undefined);
-    const autoPrior = isJan ? 0 :
-      (hasManualPrior ? safeNum(rec.priorYTD, 0) : (safeNum(rec.priorYTD, 0) || safeNum(prevRec.calculatedYTD, 0) || 0));
+    /* [FEAT OTO-ZİNCİR] Devreden GV matrahı OTOMATİK: kullanıcı elle girmez.
+       Öncelik: (1) manuel girilen, (2) önceki ayın hesaplanmış YTD'si,
+       (3) Ocak'tan bu aya kadar takvim verisinden kümülatif matrah toplamı. */
+    let autoPrior;
+    if (isJan) {
+      autoPrior = 0;
+    } else if (hasManualPrior) {
+      autoPrior = safeNum(rec.priorYTD, 0);
+    } else if (safeNum(prevRec.calculatedYTD, 0) > 0) {
+      autoPrior = safeNum(prevRec.calculatedYTD, 0);
+    } else {
+      const _cum = estimateCumulativeMatrah(u, y, m);
+      autoPrior = Math.max(0, safeNum(_cum.ytdMatrah, 0) - safeNum(_cum.monthMatrah, 0));
+    }
     priorYTDEl.value = autoPrior > 0 ? autoPrior.toFixed(2) : '0';
   }
 


### PR DESCRIPTION
Kullanıcı tercihi: takvim+elle düzeltme (zaten G-Net modunda var) ve devreden matrahın elle girilmemesi. e-Bordro açılışında priorYTD artık: 1) manuel girilmişse onu, 2) önceki ayın hesaplanmış YTD'sini, yoksa 3) estimateCumulativeMatrah ile Ocak'tan bu aya takvim verisinden kümülatif matrahı OTOMATİK toplayarak doldurur. Böylece gelir vergisi dilimi (ör. Mayıs %20) kendiliğinden doğru çıkar; kullanıcı devreden matrah girmez.

Sade maaş mantığı korunur (ek kazanç & özel kesintiler opsiyonel, varsayılan 0). FM = saat × marjinal saatlik brüt × 1,5; resmi tatil = gün × günlük brüt + çalışılan gün × günlük brüt (Md.47) — doğrulandı, gerçek bordroyla birebir.