### PR TITLE
fix: iç içe onay kutusunda kaydetme çalışmama hatası

### DIFF
--- a/app.js
+++ b/app.js
@@ -418,8 +418,13 @@ function showConfirm(title, msg, cb) {
 }
 function confirmOk() {
   const co = $('confirmOverlay'); if (co) co.classList.remove('show');
-  if (typeof confirmCallback === 'function') confirmCallback();
+  /* [FIX] İç içe onay: callback'i çağırmadan ÖNCE paylaşılan değişkeni temizle.
+     Aksi halde callback yeni bir showConfirm açarsa (ör. tatilde çalışma onayı),
+     bu fonksiyonun sonundaki null ataması o yeni callback'i siliyordu → ikinci
+     "Evet"te kaydetme çalışmıyordu (hata yok ama kayıt olmuyordu). */
+  const cb = confirmCallback;
   confirmCallback = null;
+  if (typeof cb === 'function') cb();
 }
 function confirmCancel() {
   const co = $('confirmOverlay'); if (co) co.classList.remove('show');


### PR DESCRIPTION
Resmi tatile vardiya eklerken (gün önceden izinliyse) iki onay üst üste gelir: 'İzin silinecek' → 'Tatilde çalışma'. confirmOk ilk callback'i çalıştırdıktan SONRA confirmCallback'i null yapıyordu; oysa ilk callback ikinci onayı açıp yeni callback'i (doSave) atadığından, bu null ataması onu siliyordu. Sonuç: ikinci 'Evet'te kayıt sessizce yapılmıyordu (hata yok).

Düzeltme: callback'i çağırmadan ÖNCE değişkeni temizle, böylece iç içe showConfirm yeni callback'i güvenle atayabilir.