### PR TITLE
feat(kazanç): sade 'Net Özet' kartı — günlük yevmiye modeli

### DIFF
--- a/app.js
+++ b/app.js
@@ -3911,6 +3911,7 @@ function renderEarn() {
       </button>
     </div>
   </div>
+  ${renderNetSummaryCard(u, y, m, d)}
   <div class="esb">
     <div class="esb-title"><i class="fas fa-calculator"></i>Detaylı Hesaplama</div>
     <div class="esb-grid">
@@ -3954,6 +3955,38 @@ function renderEarn() {
   ${renderEmployeeRightsPanel(u, y, m, d, e)}`;
 
   renderEarnCompare(u, y, m);
+}
+
+/* [FEAT NET-ÖZET] Günlük yevmiye modeli için sade net özet kartı:
+   günlük net × ödenen gün + resmi tatil çalışma ilavesi + fazla mesai ilavesi = aylık net.
+   Yalnızca Günlük Net modunda gösterilir. */
+function renderNetSummaryCard(u, y, m, d) {
+  if (!u || u.salaryInputMode !== 'dailyNet' || safeNum(u.dailyNetWage, 0) <= 0) return '';
+  const payroll = estimatePayrollForMonth(u, y, m, d);
+  if (!payroll || !payroll.dailyNetMode) return '';
+  const W = safeNum(u.dailyNetWage, 0);
+  const holWorked = Math.max(0, safeNum(payroll.holPayDays, 0));
+  const paidDays = Math.max(0, safeNum(payroll.dailyNetPaidDays, 0));
+  const temelGun = Math.max(0, paidDays - holWorked);
+  const temelNet = _bordroRound2(W * temelGun);
+  const tatilNet = _bordroRound2(W * holWorked);
+  const baseNet = _bordroRound2(payroll.baseNet);
+  const totalNet = _bordroRound2(payroll.net);
+  const premiumNet = Math.max(0, _bordroRound2(totalNet - baseNet));
+  const fmHours = safeNum(d.oh, 0) + safeNum(d.oh125, 0);
+  const row = (label, val, sign = '', cls = '') => `<div class="esd"><span class="ek">${label}</span><span class="ev ${cls}">${sign}${fm(val)}</span></div>`;
+  return `
+  <div class="esb" style="border:1.5px solid var(--g)">
+    <div class="esb-title" style="color:var(--g)"><i class="fas fa-wallet"></i>Net Özet — Günlük Yevmiye</div>
+    <div class="esb-detail">
+      <div class="esd"><span class="ek">Günlük net yevmiye</span><span class="ev">${fm(W)}</span></div>
+      ${row(`Temel net (${formatDayCount(temelGun)}g × ${fm(W)})`, temelNet)}
+      ${holWorked > 0 ? row(`Resmi tatilde çalışma (${formatDayCount(holWorked)}g × ${fm(W)})`, tatilNet, '+', 'pos') : ''}
+      ${premiumNet > 0 ? row(`Fazla mesai ilavesi${fmHours > 0 ? ` (${fmHours.toFixed(1)}s)` : ''}`, premiumNet, '+', 'pos') : ''}
+      <div class="esd total"><span class="ek"><i class="fas fa-money-bill-wave"></i><b>AYLIK NET</b></span><span class="ev">${fm(totalNet)}</span></div>
+    </div>
+    <div style="font-size:10.5px;opacity:.7;margin-top:6px;line-height:1.4"><i class="fas fa-info-circle"></i> Günlük net × ödenen gün + fazla mesai/resmi tatil ilaveleri. Brüt detayı için <b>e-Bordro</b> oluşturun.</div>
+  </div>`;
 }
 
 function employeeMonthKey(y, m) {

--- a/version.js
+++ b/version.js
@@ -1,3 +1,3 @@
 // Uygulama sürüm numarası — yeni güncelleme deploy ederken YALNIZCA bu dosyayı değiştir.
 // Hem service worker cache adı hem de HTML cache buster bu değeri kullanır.
-const APP_VERSION = 'shifttrack-v48';
+const APP_VERSION = 'shifttrack-v49';


### PR DESCRIPTION
Kullanıcının istediği basit net mantığını tek bakışta gösterir (Günlük Net modu):
  Temel net (günlük net × gün)
+ Resmi tatilde çalışma ilavesi (varsa)
+ Fazla mesai ilavesi (net) = AYLIK NET

Kazanç sayfasında, e-Bordro'nun brüt-ağırlıklı dökümünden önce yeşil kart olarak görünür. Brüt detay isteyen yine e-Bordro oluşturabilir. v49.