### PR TITLE
fix(Düşük 5/5): onay iptal bildirimi, SW CDN cache, firestore.rules +…

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,6 +117,7 @@ function mkUser(i) {
 }
 
 let confirmCallback = null;
+let confirmCancelCb = null; // [FIX-DÜŞÜK] onay iptal edildiğinde çağrılır (opsiyonel)
 let mdCache = {};
 let _payrollChainGuard = false; // [FIX] estimatePayrollForMonth ↔ estimateCumulativeMatrah sonsuz döngü koruması
 let yearlyOTCache = {};
@@ -411,10 +412,11 @@ function toast(msg, type = 'info', duration = 2500) {
   }, Math.max(800, safeNum(duration, 2500)));
 }
 
-function showConfirm(title, msg, cb) {
+function showConfirm(title, msg, cb, onCancel) {
   setTxt('confirmTitle', title);
   setTxt('confirmMsg', msg);
   confirmCallback = cb;
+  confirmCancelCb = (typeof onCancel === 'function') ? onCancel : null;
   const co = $('confirmOverlay'); if (co) co.classList.add('show');
 }
 function confirmOk() {
@@ -425,11 +427,17 @@ function confirmOk() {
      "Evet"te kaydetme çalışmıyordu (hata yok ama kayıt olmuyordu). */
   const cb = confirmCallback;
   confirmCallback = null;
+  confirmCancelCb = null;
   if (typeof cb === 'function') cb();
 }
 function confirmCancel() {
   const co = $('confirmOverlay'); if (co) co.classList.remove('show');
+  /* [FIX-DÜŞÜK] İptal callback'i (varsa) çağrılır — ör. vardiya kaydı iptal edildi
+     bildirimi. Önce temizle ki iç içe akışta yanlış tüketilmesin. */
+  const ccb = confirmCancelCb;
   confirmCallback = null;
+  confirmCancelCb = null;
+  if (typeof ccb === 'function') ccb();
 }
 
 function getH(ds) {
@@ -949,6 +957,11 @@ function getMD(y, m, opts = {}) {
         if (isH(startDs)) dailyHolOT += over;
       }
     });
+    /* [NOT-DÜŞÜK #1] %25 "fazla sürelerle çalışma" yasada HAFTALIK bir kavramdır
+       (sözleşme saati..45/hafta arası). 'daily75' opt-in modunda günlük FM ödenirken
+       bu band, haftalık %25 havuzuyla (weeklyOh125) sınırlanır — yani günlük FM'in
+       en çok haftalık %25 bandı kadarı %25, kalanı %50 sayılır. Bu kasıtlı ve
+       yasayla tutarlı; standart 'weekly45' modu (varsayılan) etkilenmez. */
     const dailyOT125 = Math.min(dailyOT, weeklyOh125);
     const dailyOT50 = Math.max(0, dailyOT - dailyOT125);
     if (otCalcMode === 'daily75') {
@@ -3282,6 +3295,9 @@ function saveEntry() {
       saveLS(); closeM(); renderActivePage();
     };
 
+    // [FIX-DÜŞÜK] Onay iptal edilirse kullanıcıya kaydın yapılmadığını bildir.
+    const _cancelToast = () => toast('Vardiya kaydedilmedi (iptal edildi)', 'info');
+
     // Rest time check
     const restWarn = checkRestTime(S.sd, st);
     if (restWarn) {
@@ -3292,9 +3308,10 @@ function saveEntry() {
       showConfirm(_rtTitle, _rtMsg,
         () => {
           if (checkHolidayWork(S.sd)) {
-            showConfirm('Tatil Vardiyası', `Bu gün resmi tatil! Tatilde çalışma kaydı eklenecek. Devam?`, doSave);
+            showConfirm('Tatil Vardiyası', `Bu gün resmi tatil! Tatilde çalışma kaydı eklenecek. Devam?`, doSave, _cancelToast);
           } else { doSave(); }
-        }
+        },
+        _cancelToast
       );
       return;
     }
@@ -3304,15 +3321,15 @@ function saveEntry() {
       const existingLeaveType = u.leaves[S.sd].type || 'izin';
       const proceedAfterLeaveOverwrite = () => {
         if (checkHolidayWork(S.sd)) {
-          showConfirm('Tatil Vardiyası', `Bu gün resmi tatil! Tatilde çalışma kaydı eklenecek. Devam?`, doSave);
+          showConfirm('Tatil Vardiyası', `Bu gün resmi tatil! Tatilde çalışma kaydı eklenecek. Devam?`, doSave, _cancelToast);
         } else { doSave(); }
       };
-      showConfirm('İzin Kaydı Silinecek', `Bu gün için "${existingLeaveType}" izin kaydı var. Vardiya eklenirse izin silinecek. Devam?`, proceedAfterLeaveOverwrite);
+      showConfirm('İzin Kaydı Silinecek', `Bu gün için "${existingLeaveType}" izin kaydı var. Vardiya eklenirse izin silinecek. Devam?`, proceedAfterLeaveOverwrite, _cancelToast);
       return;
     }
 
     if (checkHolidayWork(S.sd)) {
-      showConfirm('Tatil Vardiyası', `Bu gün resmi tatil! Tatilde çalışma kaydı eklenecek. Devam?`, doSave);
+      showConfirm('Tatil Vardiyası', `Bu gün resmi tatil! Tatilde çalışma kaydı eklenecek. Devam?`, doSave, _cancelToast);
       return;
     }
 
@@ -4144,6 +4161,10 @@ function estimatePayrollForMonth(u, y, m, d, priorYTDOverride) {
        üzerinden hesaplanır; vergi istisnası ücret oranını düşürmez. Bir ek günün
        marjinal brütü (W×31 − W×30) / günlük standart saat = tatil saatlik brütü. */
     const _dsh = cfg.dailyStandardHours || 7.5;
+    /* [NOT-DÜŞÜK #2] Marjinal saatlik, "30→31. gün" noktasından alınır. Çok yüksek
+       FM hacminde (kümülatif dilim üst sınıra çok yakınken) FM hafifçe düşük tahmin
+       edilebilir; tipik aylarda (gerçek bordro 19s FM) etki yok. Daha yüksek kesinlik
+       için FM saatleri toplam brüte eklenip tek computeNetFromGross ile netlenebilir. */
     const marginalDayGross = _bordroRound2(findGrossFromNet(W * 31, marital, children, priorYTD, m, undefined, y) - fullGross);
     hrGross = marginalDayGross > 0 ? _bordroRound2(marginalDayGross / _dsh)
             : (fullGross > 0 && payrollHourBasis > 0 ? _bordroRound2(fullGross / payrollHourBasis) : 0);

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,16 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Kullanıcı yalnızca kendi userData/{uid} dokümanına ve alt koleksiyonlarına erişir.
     match /userData/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read: if request.auth != null && request.auth.uid == userId;
+      // [FIX-DÜŞÜK] Temel doğrulama: kimlik + makul boyut sınırı (üst-seviye anahtar
+      // sayısı). Gerçek dokümanda ~10 üst anahtar var; 100 sınırı normal yazmayı
+      // engellemez ama bozuk/şişkin yazımı sınırlar. Şema doğrulaması bilinçli olarak
+      // gevşek tutuldu (istemci-güvenli, kullanıcıya izole).
+      allow write: if request.auth != null
+        && request.auth.uid == userId
+        && request.resource.data.keys().size() < 100;
 
       // Ara-yol: app kullanıcısı metadata dokümanı
       match /users/{appUserId} {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,10 @@
 importScripts('./version.js'); // APP_VERSION burada tanımlanır
 
 const CACHE_NAME = APP_VERSION;
+/* [FIX-DÜŞÜK] CDN varlıkları sürümden BAĞIMSIZ kalıcı cache'te tutulur — her sürüm
+   artışında yeniden indirilmesin (değişmeyen 3. parti dosyalar). Çekirdek dosyalar
+   sürümlü cache'te kalır (yeni deploy'da tazelenir). */
+const CDN_CACHE = 'shifttrack-cdn-v1';
 const CORE_ASSETS = ['./', './index.html', './version.js', './app.js', './style.css', './manifest.json', './assets/icons/icon-192.png', './assets/icons/icon-512.png'];
 const CDN_ASSETS = [
   'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800;900&display=swap',
@@ -13,18 +17,23 @@ const CDN_ASSETS = [
 
 self.addEventListener('install', e => {
   e.waitUntil(
-    caches.open(CACHE_NAME).then(cache =>
-      cache.addAll(CORE_ASSETS).then(() =>
-        Promise.allSettled(CDN_ASSETS.map(url => cache.add(url)))
+    Promise.all([
+      caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS)),
+      // CDN zaten önbellekteyse tekrar indirme (sürümden bağımsız kalıcı cache)
+      caches.open(CDN_CACHE).then(cache =>
+        Promise.allSettled(CDN_ASSETS.map(url =>
+          cache.match(url).then(hit => hit || cache.add(url))
+        ))
       )
-    ).then(() => self.skipWaiting())
+    ]).then(() => self.skipWaiting())
   );
 });
 
 self.addEventListener('activate', e => {
   e.waitUntil(
     caches.keys().then(keys => Promise.all(
-      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+      // Eski SÜRÜMLÜ çekirdek cache'lerini sil; CDN kalıcı cache'i koru.
+      keys.filter(k => k !== CACHE_NAME && k !== CDN_CACHE).map(k => caches.delete(k))
     )).then(() => self.clients.claim())
   );
 });


### PR DESCRIPTION
… #1/#2 doküman

#5: showConfirm'e iptal callback'i (onCancel); vardiya kaydı onayı iptal edilirse
    'Vardiya kaydedilmedi' bildirimi (iç içe onaylarda da).
#4: CDN varlıkları sürümden bağımsız kalıcı cache'te (shifttrack-cdn-v1) — her
    sürüm artışında yeniden indirilmiyor; çekirdek dosyalar sürümlü kalıyor.
#3: firestore.rules write'a temel boyut sınırı (üst anahtar <100) — normal yazmayı
    bozmadan bozuk/şişkin yazımı sınırlar; erişim kapsamı zaten kullanıcıya izole.
#1: daily75 %25/%50 haftalık bağımlılığı kasıtlı/yasal — netleştirici yorum. #2: dailyNet FM marjinali '30→31. gün' yaklaşımı — yüksek FM uç durumu dokümante.

15/15 test. TÜM tarama bulguları kapandı: Kritik 8/8, Orta 14/14, Düşük 10/10.