### PR TITLE
fix(ci): Node 20'de glob desteklenmiyor — 'node --test' otomatik keşf…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Bağımlılıkları kur

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test \"tests/**/*.test.mjs\"",
+    "test": "node --test",
     "lint": "eslint ."
   },
   "devDependencies": {


### PR DESCRIPTION
…e geç, CI Node 22

'node --test "tests/**/*.test.mjs"' deseni CI'daki Node 20'de açılmıyor ve 'Could not find ...' ile düşüyordu. Argümansız 'node --test' tüm Node 20+ sürümlerinde test dosyalarını otomatik keşfeder (node_modules hariç). CI Node sürümü 22'ye yükseltildi (runner'daki Node 20 deprecation uyarısı).