### PR TITLE
fix(kozmetik): og:image mutlak URL + location.reload(true) temizliği

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
 <meta property="og:title" content="ShiftTrack Pro">
 <meta property="og:description" content="Vardiya takibi, fazla mesai ve Türkiye bordro/maaş hesaplama — çevrimdışı çalışabilen, bulut senkronlu PWA.">
 <meta property="og:type" content="website">
-<meta property="og:image" content="assets/icons/icon-512.png">
+<meta property="og:image" content="https://voidcoder-ux.github.io/Shiftt/assets/icons/icon-512.png">
+<meta property="og:url" content="https://voidcoder-ux.github.io/Shiftt/">
 <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://*.firebaseapp.com https://*.googleapis.com https://*.gstatic.com https://*.google.com https://apis.google.com https://cdnjs.cloudflare.com https://fonts.googleapis.com https://fonts.gstatic.com https://api.deepseek.com; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.gstatic.com https://apis.google.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.firebaseapp.com https://*.googleapis.com https://*.google.com https://api.deepseek.com wss://*.firebaseapp.com https://*.firebaseio.com; frame-src 'self' https://*.firebaseapp.com https://*.google.com https://accounts.google.com; object-src 'none'">
 <script src="version.js"></script>
 <script>
@@ -26,7 +27,7 @@
           // her sürüm artışında yeniden indirilmesin (bkz. sw.js CDN_CACHE).
           var del = keys.filter(function(k) { return k.indexOf('shifttrack-cdn') !== 0; });
           Promise.all(del.map(function(k) { return caches.delete(k); })).then(function() {
-            location.reload(true);
+            location.reload();
           });
         });
       });


### PR DESCRIPTION
## Özet

Hızlı kalite taramasında bulunan 2 kozmetik düzeltme:

1. **`og:image` mutlak URL yapıldı** — sosyal medya tarayıcıları (WhatsApp, X vb.) göreli yolu kabul etmediğinden paylaşım önizlemesinde görsel çıkmıyordu. GitHub Pages adresi kullanıldı (`https://voidcoder-ux.github.io/Shiftt/`) ve `og:url` etiketi eklendi.
2. **`location.reload(true)` → `location.reload()`** — boolean parametre modern tarayıcılarda kullanım dışı ve etkisiz.

Davranış değişikliği yok; build yerelde doğrulandı.

https://claude.ai/code/session_01Tf3VjqRKui1bZFoekUqCA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tf3VjqRKui1bZFoekUqCA4)_