### PR TITLE
Takvim hücresinde normal + FM saat ayrımı gösterimi

### DIFF
--- a/app.js
+++ b/app.js
@@ -2558,6 +2558,13 @@ function renderCal() {
   /* [FIX] Akıllı Vardiya Önerileri — renderCal başında bir kere hesapla */
   const suggestions = getSmartSuggestions(y, m);
 
+  /* Takvim hücresinde normal + FM ayrımı — yalnızca görsel etiket, hesap mantığı
+     getMD'dedir ve değişmez. Günlük eşik getMD ile aynı formül (min 7,5 / aylık÷30).
+     'weekly45' modunda FM hafta bazlı olduğundan gün içinde ayrıştırılamaz; toplam gösterilir. */
+  const otSplitOn = u.otCalcMode === 'daily75' || u.otCalcMode === 'hybrid';
+  const dailyStdDisplay = Math.min(7.5, Math.max(1, getMonthlyHours(u) / 30));
+  const fmtH = v => (Math.abs(v % 1) < 0.05 ? v.toFixed(0) : v.toFixed(1));
+
   for (let d = 1; d <= dim; d++) {
     const s = `${y}-${String(m+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
     const e = document.createElement('div');
@@ -2594,7 +2601,12 @@ function renderCal() {
       const shiftLabel = sh ? `${escHtml(sh.start)}–${escHtml(sh.end)}` : `${escHtml(partLabel)} (devam)`;
       /* [FIX L-06] FM yasal olarak 45s/hafta bazlıdır, günlük 9s sınırı yoktur.
          CSS sınıfı 'long-shift' olarak yeniden adlandırıldı; 8.5s üstü uzun vardiya göstergesi. */
-      inner += `<div class="hrs-display ${h > 8.5 ? 'long-shift' : ''}">${h.toFixed(1)}s</div>`;
+      const otPart = otSplitOn ? Math.max(0, h - dailyStdDisplay) : 0;
+      if (otPart > 0.05) {
+        inner += `<div class="hrs-display split" title="Toplam ${h.toFixed(1)}s: ${(h - otPart).toFixed(1)}s normal + ${otPart.toFixed(1)}s FM">${fmtH(h - otPart)}<span class="hrs-ot">+${fmtH(otPart)}</span></div>`;
+      } else {
+        inner += `<div class="hrs-display ${h > 8.5 ? 'long-shift' : ''}">${h.toFixed(1)}s</div>`;
+      }
       inner += `<div class="shift-icon">${sType.icon}</div>`;
       inner += `<div class="shift-time">${shiftLabel}${isNightShift(displayShift.start, displayShift.end) ? ' 🌙' : ''}</div>`;
       if (displayShift.note) inner += `<div class="shift-time" style="color:var(--p3);opacity:.7">📝 ${escHtml(displayShift.note.substring(0,20))}</div>`;

--- a/style.css
+++ b/style.css
@@ -223,6 +223,8 @@ body{font-family:'Plus Jakarta Sans',system-ui,sans-serif;background:var(--bg);c
 .cal-cell .hrs-display{font-size:16px;font-weight:900;color:var(--g);line-height:1;margin:2px 0}
 .cal-cell .hrs-display.overtime{color:var(--acc)}
 .cal-cell .hrs-display.long-shift{color:var(--acc)}
+.cal-cell .hrs-display.split{font-size:13px;letter-spacing:-.3px;white-space:nowrap}
+.cal-cell .hrs-display .hrs-ot{color:var(--acc)}
 .cal-cell .shift-time{font-size:9px;color:var(--t2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .cal-cell .leave-display{margin-top:2px;display:flex;align-items:center;gap:4px;font-size:10px;font-weight:800}
 .cal-cell .leave-display.ld-annual{color:#60a5fa}.cal-cell .leave-display.ld-weekly{color:var(--p)}.cal-cell .leave-display.ld-sick{color:#fb923c}.cal-cell .leave-display.ld-unpaid{color:#94a3b8}
@@ -639,7 +641,7 @@ tr:hover td{background:var(--bg3)}
 @media(max-width:768px){
 .content{padding:118px 10px 28px;max-width:100%;width:100%;overflow-x:hidden}.grid-2,.grid-3{grid-template-columns:1fr}.stats{grid-template-columns:repeat(2,1fr)}
 .ai-page-grid{grid-template-columns:1fr}.ai-metric-grid{grid-template-columns:repeat(2,1fr)}.ai-hero .value{font-size:24px}.ai-api-grid{grid-template-columns:1fr}.ai-api-actions{justify-content:flex-end}
-.cal-cell{min-height:56px;padding:4px 5px}.cal-cell .shift-time,.cal-cell .leave-label,.cal-cell .hol-tag{display:none}.cal-cell .hrs-display{font-size:13px}.cal-cell .leave-display{font-size:9px}.cal-cell .shift-icon{display:block}.ss-grid{grid-template-columns:repeat(auto-fill,minmax(100px,1fr))}
+.cal-cell{min-height:56px;padding:4px 5px}.cal-cell .shift-time,.cal-cell .leave-label,.cal-cell .hol-tag{display:none}.cal-cell .hrs-display{font-size:13px}.cal-cell .hrs-display.split{font-size:11px}.cal-cell .leave-display{font-size:9px}.cal-cell .shift-icon{display:block}.ss-grid{grid-template-columns:repeat(auto-fill,minmax(100px,1fr))}
 .earn-hero .amt{font-size:24px}.nav-tab span{display:none}.nav-tab{padding:10px 12px}.nav-tab i{font-size:17px}
 .login-cards{flex-direction:column;align-items:center}.year-overview{grid-template-columns:repeat(6,1fr)}
 .page-head{flex-direction:column;align-items:flex-start}.cal-earn-bar{flex-direction:column;align-items:flex-start}.result-box .rb-val{font-size:13px}
@@ -661,7 +663,7 @@ tr:hover td{background:var(--bg3)}
 .auth-box{padding:24px 18px;margin:0 8px;max-width:100%}.auth-box .auth-brand h1{font-size:18px}.auth-box .auth-brand p{font-size:11px}.auth-fg input{font-size:16px}.auth-skip{font-size:12px;padding:10px}
 .modal{width:100%;max-width:95vw}.calc-box{max-width:95vw;padding:18px}.employer-box{max-width:95vw;padding:18px}.calc-overlay,.employer-overlay,.overlay{padding:8px}
 /* [FIX CSS-GÖRSEL-01] Takvim hücreleri 480px altında kompakt mod */
-.cal-grid{gap:2px}.cal-cell{min-height:56px;padding:3px 3px}.cal-cell .num{font-size:10px}.cal-cell .hrs-display{font-size:9px;padding:1px 3px}.cal-cell .shift-time{font-size:8px;display:none}.cal-cell .shift-icon{font-size:13px}.cal-cell .leave-display{font-size:9px;padding:2px 3px}.cal-cell .hol-tag{font-size:7px;padding:1px 2px}.cal-dname{font-size:8px;padding:4px 0}}
+.cal-grid{gap:2px}.cal-cell{min-height:56px;padding:3px 3px}.cal-cell .num{font-size:10px}.cal-cell .hrs-display{font-size:9px;padding:1px 3px}.cal-cell .hrs-display.split{font-size:8px}.cal-cell .shift-time{font-size:8px;display:none}.cal-cell .shift-icon{font-size:13px}.cal-cell .leave-display{font-size:9px;padding:2px 3px}.cal-cell .hol-tag{font-size:7px;padding:1px 2px}.cal-dname{font-size:8px;padding:4px 0}}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;transition-duration:.01ms!important}}
 
 /* ===== EVRAKLARIM ===== */


### PR DESCRIPTION
Günlük FM modunda (daily75/hybrid) takvim hücresi toplam saat yerine '7.5+5' biçiminde normal + fazla mesai ayrımını gösterir. FM kısmı vurgu rengiyle ayrılır, üzerine gelince toplam ve ayrıntı görünür. Yalnızca görsel etiket — getMD hesap mantığı değişmedi; weekly45 modunda FM hafta bazlı olduğundan toplam gösterim korunur.

https://claude.ai/code/session_01BDFrXB5nsLx5bZoRVgF2AH